### PR TITLE
Getting join tables

### DIFF
--- a/generators/js/data_colors.js
+++ b/generators/js/data_colors.js
@@ -1,5 +1,6 @@
 //
 // Generate code to create colors data frame for testing.
+// FIXME: how does this work when `parseInts` takes a single argument?
 //
 Blockly.JavaScript['data_colors'] = (block) => {
   const prefix = registerPrefix('')

--- a/generators/js/ggplot_bar.js
+++ b/generators/js/ggplot_bar.js
@@ -27,5 +27,5 @@ Blockly.JavaScript['ggplot_bar'] = (block) => {
     }
   }`
   const suffix = registerSuffix('')
-  return `.plot(tableEmbed, vegaEmbed, '#plotOutput', ${spec}) ${suffix}`
+  return `.plot(tableEmbed, plotEmbed, ${spec}) ${suffix}`
 }

--- a/generators/js/ggplot_boxplot.js
+++ b/generators/js/ggplot_boxplot.js
@@ -25,5 +25,5 @@ Blockly.JavaScript['ggplot_boxplot'] = (block) => {
     }
   }`
   const suffix = registerSuffix('')
-  return `.plot(tableEmbed, vegaEmbed, '#plotOutput', ${spec}) ${suffix}`
+  return `.plot(tableEmbed, plotEmbed, ${spec}) ${suffix}`
 }

--- a/generators/js/ggplot_hist.js
+++ b/generators/js/ggplot_hist.js
@@ -26,5 +26,5 @@ Blockly.JavaScript['ggplot_hist'] = (block) => {
     }
   }`
   const suffix = registerSuffix('')
-  return `.plot(tableEmbed, vegaEmbed, '#plotOutput', ${spec}) ${suffix}`
+  return `.plot(tableEmbed, plotEmbed, ${spec}) ${suffix}`
 }

--- a/generators/js/ggplot_point.js
+++ b/generators/js/ggplot_point.js
@@ -31,5 +31,5 @@ Blockly.JavaScript['ggplot_point'] = (block) => {
     }
   }`
   const suffix = registerSuffix('')
-  return `.plot(tableEmbed, vegaEmbed, '#plotOutput', ${spec}) ${suffix}`
+  return `.plot(tableEmbed, plotEmbed, ${spec}) ${suffix}`
 }

--- a/generators/js/ggplot_table.js
+++ b/generators/js/ggplot_table.js
@@ -3,5 +3,5 @@
 //
 Blockly.JavaScript['ggplot_table'] = (block) => {
   const suffix = registerSuffix('')
-  return `.plot(tableEmbed, null, '#plotOutput', {}) ${suffix}`
+  return `.plot(tableEmbed, null, {}) ${suffix}`
 }

--- a/generators/js/plumbing_join.js
+++ b/generators/js/plumbing_join.js
@@ -8,5 +8,5 @@ Blockly.JavaScript['plumbing_join'] = (block) => {
   const rightName = block.getFieldValue('rightName')
   const rightColumn = Blockly.JavaScript.valueToCode(block, 'rightColumn', order)
   const prefix = registerPrefix(`'${leftName}', '${rightName}'`)
-  return `${prefix} new TidyBlocksDataFrame([]).join('${leftName}', '${leftColumn}', '${rightName}', '${rightColumn}')`
+  return `${prefix} new TidyBlocksDataFrame([]).join((name) => TidyBlocksManager.get(name), '${leftName}', '${leftColumn}', '${rightName}', '${rightColumn}')`
 }

--- a/index.html
+++ b/index.html
@@ -225,6 +225,11 @@
         setUpBlockly()
       })
 
+      // Display a plot.
+      const plotEmbed = (spec) => {
+        vegaEmbed('#plotOutput', spec, {})
+      }
+
       // Display a table.
       const tableEmbed = (result) => {
         const table = json2table(result)

--- a/tests/test.js
+++ b/tests/test.js
@@ -115,10 +115,18 @@ const vegaEmbed = (htmlID, spec, props) => {
 
 /**
  * Display a table (ish).
- * @param result {JSON[]} - data to display.
+ * @param data {JSON[]} - data to display.
  */
-const tableEmbed = (result) => {
-  console.log(result)
+const tableEmbed = (data) => {
+  console.log(data)
+}
+
+/**
+ * Display a plot (ish).
+ * @param spec {JSON[]} - Vega-Lite spec to display.
+ */
+const plotEmbed = (spec) => {
+  console.log(spec)
 }
 
 //--------------------------------------------------------------------------------

--- a/utilities/tb_dataframe.js
+++ b/utilities/tb_dataframe.js
@@ -3,6 +3,11 @@
  */
 class TidyBlocksDataFrame {
 
+  /**
+   * Lookup table of summarization functions.  Each takes an array of values as
+   * input and returns a single value as output.
+   * FIXME: replace this with DataForge summarization.
+   */
   static GetSummarizeFunction (name) {
     return {
       count: (values) => {
@@ -46,10 +51,22 @@ class TidyBlocksDataFrame {
     }[name]
   }
 
+  /**
+   * Build a TidyBlocks dataframe that wraps a DataForge dataframe.
+   * @param initial {array} - array of JSON records.
+   */
   constructor (initial) {
     this.df = this.makeDataFrame(initial)
   }
 
+  /**
+   * Construct the underlying DataForge dataframe.  If 'module' is defined, this
+   * class is being loaded by Node on the command line for testing purposes, so
+   * we need to use 'require'. If 'modules' isn't defined, this file is being
+   * loaded by the browser, so no 'require' is needed.
+   * @param initial {array} - array of JSON records.
+   * @return dataForge.DataFrame
+   */
   makeDataFrame (initial) {
     // Create dataForge dataframe when running on the command line.
     if (typeof module !== 'undefined') {
@@ -62,26 +79,53 @@ class TidyBlocksDataFrame {
     }
   }
 
+  /**
+   * Generate a new series (e.g. for mutating).
+   * @param props {Object} - parameters for DataForge series generation.
+   * @return this object (for method chaining)
+   */
   generateSeries (props) {
     this.df = this.df.generateSeries(props)
     return this
   }
 
+  /**
+   * Turn one or more columns into integer values (from text).
+   * FIXME: the call in `generators/js/data_colors.js` passes in multiple arguments?
+   * @param columns {array} - columns to convert.
+   * @return this object (for method chaining)
+   */
   parseInts (columns) {
     this.df.parseInts(columns)
     return this
   }
 
+  /**
+   * Order according to the given function.
+   * @param func {function} - calculate ordering index.
+   * @return this object (for method chaining)
+   */
   orderBy (func) {
     this.df = this.df.orderBy(func)
     return this
   }
 
+  /**
+   * Extract subset of columns.
+   * @param columns {string[]} - columns to subset.
+   * @return this object (for method chaining).
+   */
   subset (columns) {
     this.df = this.df.subset(columns)
     return this
   }
 
+  /**
+   * Replace internal dataframe with a summarized dataframe.
+   * FIXME: replace with DataForge summarization.
+   * @param whatToDo {object} - function name and column name.
+   * @return this object (for method chaining)
+   */
   summarize (whatToDo) {
     // Setup.
     const {func, column} = whatToDo
@@ -124,24 +168,47 @@ class TidyBlocksDataFrame {
     return this
   }
 
+  /*
+   * Filter rows, keeping those that pass function test.
+   * @param func {function} - filter test.
+   * @return this object (for method chaining)
+   */
   where (func) {
     this.df = this.df.where(func)
     return this
   }
 
-  plot (tableFxn, plotFxn, htmlID, spec) {
+  /**
+   * Call a plotting function. This is in this class to support method chaining
+   * and to decouple this class from the real plotting functions so that tests
+   * will run.
+   * @param tableFxn {function} - callback to display table as table.
+   * @param plotFxn {function} - callback to display table graphically.
+   * @param spec {object} - Vega-Lite specification with empty 'values' (filled in here with actual data before plotting).
+   * @return this object (for method chaining)
+   */
+  plot (tableFxn, plotFxn, spec) {
     const asArray = this.df.toArray()
     if (tableFxn !== null) {
       tableFxn(asArray)
     }
     if (plotFxn !== null) {
       spec.data.values = asArray
-      plotFxn(htmlID, spec, {})
+      plotFxn(spec)
     }
     return this
   }
 
-  join (leftTable, leftColumn, rightTable, rightColumn) {
+  /**
+   * Join two tables on equality between values in specified columns.
+   * @param getDataFxn {function} - how to look up data by name.
+   * @param leftTable {string} - notification name of left table to join.
+   * @param leftColumn {string} - name of column from left table.
+   * @param rightTable {string} - notification name of right table to join.
+   * @param rightColumn {string} - name of column from right table.
+   * @result this object (for method chaining) with new joined DataForge dataframe.
+   */
+  join (getDataFxn, leftTable, leftColumn, rightTable, rightColumn) {
     this.df = this.makeDataFrame([
       {table: leftTable,  column: leftColumn},
       {table: rightTable, column: rightColumn}
@@ -149,10 +216,20 @@ class TidyBlocksDataFrame {
     return this
   }
 
+  /**
+   * Notify the pipeline manager that this pipeline has completed so that downstream joins can run.
+   * Note that this function is called at the end of a pipeline, so it does not return 'this' to support method chaining.
+   * @param notifyFxn {function} - callback functon to do notification (to decouple this class from the manager).
+   * @param name {string} - name of this pipeline.
+   */
   notify (notifyFxn, name) {
-    notifyFxn(name)
+    notifyFxn(name, this)
   }
 
+  /**
+   * Extract data from underlying DataForge dataframe as JavaScript array of objects.
+   * @return array of objects.
+   */
   toArray () {
     return this.df.toArray()
   }

--- a/utilities/tb_manager.js
+++ b/utilities/tb_manager.js
@@ -1,17 +1,33 @@
 /**
- * Manage all pipelines.
+ * Manage execution of all data pipelines.
  */
 class TidyBlocksManagerClass {
 
+  /**
+   * Create manager.
+   */
   constructor () {
     this.reset()
   }
 
+  /**
+   * Re-set internal variables used to track state of execution.
+   * `queue` is the queue of pipeline functions that are ready to run.
+   * `waiting` maps those functions to the names of the things they depend on.
+   * `data` maps notification names to finished dataframes.
+   */
   reset () {
     this.queue = []
     this.waiting = new Map()
+    this.data = new Map()
   }
 
+  /**
+   * Register a new pipeline function with what it depends on and what it produces.
+   * @param depends {string[]} - names of things this pipeline depends on (if it starts with a join).
+   * @param func {function} - function encapsulating pipeline to run.
+   * @param produces {function} - name of this pipeline (used to trigger things waiting for it).
+   */
   register (depends, func, produces) {
     if (depends.length == 0) {
       this.queue.push(func)
@@ -21,7 +37,14 @@ class TidyBlocksManagerClass {
     }
   }
 
-  notify (name) {
+  /**
+   * Notify the manager that a named pipeline has finished running.
+   * This enqueues pipeline functions to run if their dependencies are satisfied.
+   * @param name {string} - name of the pipeline that just completed.
+   * @param dataFrame {Object} - the TidyBlocksDataFrame produced by the pipeline.
+   */
+  notify (name, dataFrame) {
+    this.data.set(name, dataFrame)
     this.waiting.forEach((dependencies, func) => {
       dependencies.delete(name)
       if (dependencies.size === 0) {
@@ -30,6 +53,10 @@ class TidyBlocksManagerClass {
     })
   }
 
+  /**
+   * Run all pipelines in an order that respects dependencies.
+   * This depends on `notify` to add pipelines to the queue.
+   */
   run () {
     while (this.queue.length > 0) {
       const func = this.queue.shift()
@@ -38,11 +65,26 @@ class TidyBlocksManagerClass {
     this.reset()
   }
 
+  /**
+   * Get the data associated with the name of a completed pipeline.
+   * @param name {string} - name of completed pipeline.
+   * @return TidyBlocksDataFrame.
+   */
+  get (name) {
+    return this.data.get(name)
+  }
+
+  /**
+   * Show the manager as a string for debugging.
+   */
   toString () {
     return 'queue ' + this.queue + ' waiting ' + this.waiting
   }
 }
 
+/**
+ * Singleton instance of manager.
+ */
 const TidyBlocksManager = new TidyBlocksManagerClass()
 
 //


### PR DESCRIPTION
1. Storing references to dataframes in `TidyBlocksManager` when pipelines complete so that joins can get the data they need.
1. Passing a function to the `join` method to look up the dataframes needed in the join.
1. Wrote documentation for internal classes.
1. Pass an anonymous function of one argument for creating plots rather than passing Vega-Lite specific stuff.