### PR TITLE
Simplifying code generation a bit.

### DIFF
--- a/blocks/dplyr_filter.js
+++ b/blocks/dplyr_filter.js
@@ -7,7 +7,7 @@ Blockly.Blocks['dplyr_filter'] = {
       .appendDummyInput()
       .appendField('Filter')
     this
-      .appendValueInput('Columns')
+      .appendValueInput('Column')
       .setCheck(null)
     this.setInputsInline(true)
     this.setPreviousStatement(true, 'Array')

--- a/blocks/dplyr_groupby.js
+++ b/blocks/dplyr_groupby.js
@@ -7,7 +7,7 @@ Blockly.Blocks['dplyr_groupby'] = {
       .appendDummyInput()
       .appendField('Group by')
     this
-      .appendValueInput('Columns')
+      .appendValueInput('Column')
       .setCheck(null)
     this.setInputsInline(true)
     this.setPreviousStatement(true, 'Array')

--- a/blocks/dplyr_mutate.js
+++ b/blocks/dplyr_mutate.js
@@ -7,7 +7,7 @@ Blockly.Blocks['dplyr_mutate'] = {
       .appendDummyInput()
       .appendField('Mutate')
     this
-      .appendValueInput('Columns')
+      .appendValueInput('Column')
       .setCheck(null)
       .appendField(new Blockly.FieldTextInput('new column'), 'newCol')
     this.setInputsInline(true)

--- a/blocks/dplyr_select.js
+++ b/blocks/dplyr_select.js
@@ -7,7 +7,7 @@ Blockly.Blocks['dplyr_select'] = {
       .appendDummyInput()
       .appendField('Select')
     this
-      .appendValueInput('Columns')
+      .appendValueInput('Column')
       .setCheck(null)
     this.setInputsInline(true)
     this.setPreviousStatement(true, 'Array')

--- a/blocks/dplyr_summarize.js
+++ b/blocks/dplyr_summarize.js
@@ -7,7 +7,7 @@ Blockly.Blocks['dplyr_summarize'] = {
       .appendDummyInput()
       .appendField('Summarize')
     this
-      .appendValueInput('Columns')
+      .appendValueInput('Column')
       .setCheck(null)
     this.setInputsInline(true)
     this.setPreviousStatement(true, 'Array')

--- a/blocks/ggplot_hist.js
+++ b/blocks/ggplot_hist.js
@@ -4,7 +4,7 @@
 Blockly.Blocks['ggplot_hist'] = {
   init: function() {
     this
-      .appendValueInput('Columns')
+      .appendValueInput('Column')
       .setCheck(null)
       .appendField('Histogram')
     this

--- a/blocks/stats_count.js
+++ b/blocks/stats_count.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/blocks/stats_max.js
+++ b/blocks/stats_max.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/blocks/stats_mean.js
+++ b/blocks/stats_mean.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/blocks/stats_median.js
+++ b/blocks/stats_median.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/blocks/stats_min.js
+++ b/blocks/stats_min.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/blocks/stats_sd.js
+++ b/blocks/stats_sd.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/blocks/stats_sum.js
+++ b/blocks/stats_sum.js
@@ -11,7 +11,7 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'input_value',
-        name: 'Columns'
+        name: 'Column'
       }
     ],
     inputsInline: true,

--- a/generators/js/data_colors.js
+++ b/generators/js/data_colors.js
@@ -1,6 +1,5 @@
 //
 // Generate code to create colors data frame for testing.
-// FIXME: how does this work when `parseInts` takes a single argument?
 //
 Blockly.JavaScript['data_colors'] = (block) => {
   const prefix = registerPrefix('')

--- a/generators/js/dplyr_filter.js
+++ b/generators/js/dplyr_filter.js
@@ -2,6 +2,6 @@
 // Filter data.
 //
 Blockly.JavaScript['dplyr_filter'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-  return `.where(row => (${argColumns}))`
+  const argColumn = colValue(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  return `.where(row => (${argColumn}))`
 }

--- a/generators/js/dplyr_groupby.js
+++ b/generators/js/dplyr_groupby.js
@@ -2,7 +2,6 @@
 // Group data.
 //
 Blockly.JavaScript['dplyr_groupby'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-  return `.generateSeries({ Index: row => ${argColumns}})`
-    .replace(/&&/gi, '+')
+  const argColumn = colValue(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  return `.generateSeries({Index: row => ${argColumn}})`
 }

--- a/generators/js/dplyr_mutate.js
+++ b/generators/js/dplyr_mutate.js
@@ -3,7 +3,6 @@
 //
 Blockly.JavaScript['dplyr_mutate'] = (block) => {
   const argNewCol = block.getFieldValue('newCol')
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-  return `.generateSeries({ ${argNewCol}: row => ${argColumns} })`
-         .replace(/["']/g, '')
+  const argColumn = colValue(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  return `.generateSeries({${argNewCol}: row => ${argColumn}})`
 }

--- a/generators/js/dplyr_select.js
+++ b/generators/js/dplyr_select.js
@@ -2,10 +2,6 @@
 // Select columns.
 //
 Blockly.JavaScript['dplyr_select'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, ' ')
-        .replace(/&&/g, ',')
-        .replace(/ /gi, '')
-        .replace(/,/gi, '","')
-  return `.subset(["${argColumns}"])`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  return `.subset(["${argColumn}"])`
 }

--- a/generators/js/dplyr_summarize.js
+++ b/generators/js/dplyr_summarize.js
@@ -2,6 +2,6 @@
 // Summarize data.
 //
 Blockly.JavaScript['dplyr_summarize'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-  return `.summarize(${argColumns})`
+  const argColumn = colValue(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  return `.summarize(${argColumn})`
 }

--- a/generators/js/ggplot_bar.js
+++ b/generators/js/ggplot_bar.js
@@ -2,10 +2,8 @@
 // Create a bar plot.
 //
 Blockly.JavaScript['ggplot_bar'] = (block) => {
-  const argX =  Blockly.JavaScript.valueToCode(block, 'X', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, "")
-  const argY =  Blockly.JavaScript.valueToCode(block, 'Y', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, "")
+  const argX =  colName(Blockly.JavaScript.valueToCode(block, 'X', Blockly.JavaScript.ORDER_NONE))
+  const argY =  colName(Blockly.JavaScript.valueToCode(block, 'Y', Blockly.JavaScript.ORDER_NONE))
   const spec = `{
     "width": 500,
     "height": 300,

--- a/generators/js/ggplot_boxplot.js
+++ b/generators/js/ggplot_boxplot.js
@@ -2,10 +2,8 @@
 // Create a box plot.
 //
 Blockly.JavaScript['ggplot_boxplot'] = (block) => {
-  const argX = Blockly.JavaScript.valueToCode(block, 'X', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, '')
-  const argY = Blockly.JavaScript.valueToCode(block, 'Y', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, '')
+  const argX = colName(Blockly.JavaScript.valueToCode(block, 'X', Blockly.JavaScript.ORDER_NONE))
+  const argY = colName(Blockly.JavaScript.valueToCode(block, 'Y', Blockly.JavaScript.ORDER_NONE))
   const spec = `{
     "width": 500,
     "data": { "values": null }, // set to dataframe inside plotting function

--- a/generators/js/ggplot_hist.js
+++ b/generators/js/ggplot_hist.js
@@ -2,8 +2,7 @@
 // Create a histogram.
 //
 Blockly.JavaScript['ggplot_hist'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, '')
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
   const argBins = block.getFieldValue('bins')
   const spec = `{
     "width": 500,
@@ -15,7 +14,7 @@ Blockly.JavaScript['ggplot_hist'] = (block) => {
         "bin": {
           "maxbins": ${argBins}
         },
-        "field": "${argColumns}",
+        "field": "${argColumn}",
         "type": "quantitative"
       },
       "y": {

--- a/generators/js/ggplot_point.js
+++ b/generators/js/ggplot_point.js
@@ -3,12 +3,9 @@
 // FIXME: restore the LM material.
 //
 Blockly.JavaScript['ggplot_point'] = (block) => {
-  const argX = Blockly.JavaScript.valueToCode(block, 'X', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, '')
-  const argY = Blockly.JavaScript.valueToCode(block, 'Y', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, '')
-  const argColor = Blockly.JavaScript.valueToCode(block, 'color', Blockly.JavaScript.ORDER_NONE)
-        .replace(/row./gi, '')
+  const argX = colName(Blockly.JavaScript.valueToCode(block, 'X', Blockly.JavaScript.ORDER_NONE))
+  const argY = colName(Blockly.JavaScript.valueToCode(block, 'Y', Blockly.JavaScript.ORDER_NONE))
+  const argColor = colName(Blockly.JavaScript.valueToCode(block, 'color', Blockly.JavaScript.ORDER_NONE))
   const useLM = (block.getFieldValue('lm') == 'FALSE')
 
   const spec = `{

--- a/generators/js/plumbing_join.js
+++ b/generators/js/plumbing_join.js
@@ -4,9 +4,9 @@
 Blockly.JavaScript['plumbing_join'] = (block) => {
   const order = Blockly.JavaScript.ORDER_NONE
   const leftName = block.getFieldValue('leftName')
-  const leftColumn = Blockly.JavaScript.valueToCode(block, 'leftColumn', order)
+  const leftColumn = colName(Blockly.JavaScript.valueToCode(block, 'leftColumn', order))
   const rightName = block.getFieldValue('rightName')
-  const rightColumn = Blockly.JavaScript.valueToCode(block, 'rightColumn', order)
+  const rightColumn = colName(Blockly.JavaScript.valueToCode(block, 'rightColumn', order))
   const prefix = registerPrefix(`'${leftName}', '${rightName}'`)
   return `${prefix} new TidyBlocksDataFrame([]).join((name) => TidyBlocksManager.get(name), '${leftName}', '${leftColumn}', '${rightName}', '${rightColumn}')`
 }

--- a/generators/js/stats_arithmetic.js
+++ b/generators/js/stats_arithmetic.js
@@ -10,8 +10,8 @@ Blockly.JavaScript['stats_arithmetic'] = (block) => {
   }
   const order = Blockly.JavaScript.ORDER_NONE
   const argOperator = OPERATORS[block.getFieldValue('OP')]
-  const argLeft = Blockly.JavaScript.valueToCode(block, 'A', order)
-  const argRight = Blockly.JavaScript.valueToCode(block, 'B', order)
-  const code = `parseFloat(${argLeft}) ${argOperator} parseFloat(${argRight})`
+  const argLeft = colValue(Blockly.JavaScript.valueToCode(block, 'A', order))
+  const argRight = colValue(Blockly.JavaScript.valueToCode(block, 'B', order))
+  const code = `${argLeft} ${argOperator} ${argRight}`
   return [code, order]
 }

--- a/generators/js/stats_count.js
+++ b/generators/js/stats_count.js
@@ -2,8 +2,7 @@
 // Count the number of items.
 //
 Blockly.JavaScript['stats_count'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace('row.', '')
-  const code = `{ func: 'count', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'count', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/stats_max.js
+++ b/generators/js/stats_max.js
@@ -2,8 +2,7 @@
 // Calculate max.
 //
 Blockly.JavaScript['stats_max'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace('row.', '')
-  const code = `{ func: 'max', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'max', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/stats_mean.js
+++ b/generators/js/stats_mean.js
@@ -2,8 +2,7 @@
 // Find the mean.
 //
 Blockly.JavaScript['stats_mean'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace('row.', '')
-  const code = `{ func: 'mean', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'mean', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/stats_median.js
+++ b/generators/js/stats_median.js
@@ -2,8 +2,7 @@
 // Find the median of the data.
 //
 Blockly.JavaScript['stats_median'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace('row.', '')
-  const code = `{ func: 'median', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'median', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/stats_min.js
+++ b/generators/js/stats_min.js
@@ -2,8 +2,7 @@
 // Find the minimum of the data.
 //
 Blockly.JavaScript['stats_min'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace("row.", "")
-  const code = `{ func: 'min', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'min', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/stats_sd.js
+++ b/generators/js/stats_sd.js
@@ -2,8 +2,7 @@
 // Find the standard deviation of the data.
 //
 Blockly.JavaScript['stats_sd'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace("row.", "")
-  const code = `{ func: 'sd', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'sd', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/stats_sum.js
+++ b/generators/js/stats_sum.js
@@ -2,8 +2,7 @@
 // Calculate the sum of the data.
 //
 Blockly.JavaScript['stats_sum'] = (block) => {
-  const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-        .replace('row.', '')
-  const code = `{ func: 'sum', column: '${argColumns}' }`
+  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
+  const code = `{func: 'sum', column: '${argColumn}'}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/generators/js/variable_column.js
+++ b/generators/js/variable_column.js
@@ -1,9 +1,8 @@
 //
-// Represent a column name.
+// Represent a column name. Prefix with an '@' to indicate that it's a column
+// name; other code will then handle.
 //
 Blockly.JavaScript['variable_column'] = (block) => {
-  const code = 'row.' +
-        Blockly.JavaScript.quote_(block.getFieldValue('TEXT'))
-        .replace(/["']/g, '')
+  const code = '@' + block.getFieldValue('TEXT')
   return [code, Blockly.JavaScript.ORDER_ATOMIC]
 }

--- a/generators/js/variable_compare.js
+++ b/generators/js/variable_compare.js
@@ -14,8 +14,8 @@ Blockly.JavaScript['variable_compare'] = (block) => {
   const order = (operator === '==' || operator === '!=')
         ? Blockly.JavaScript.ORDER_EQUALITY
         : Blockly.JavaScript.ORDER_RELATIONAL
-  const A = Blockly.JavaScript.valueToCode(block, 'A', order) || '0' // FIXME: why the fallback?
-  const B = Blockly.JavaScript.valueToCode(block, 'B', order) || '0'
+  const A = colValue(Blockly.JavaScript.valueToCode(block, 'A', order))
+  const B = colValue(Blockly.JavaScript.valueToCode(block, 'B', order))
   const code = `${A} ${operator} ${B}`
   return [code, order]
 }

--- a/generators/js/variable_logical.js
+++ b/generators/js/variable_logical.js
@@ -5,8 +5,8 @@ Blockly.JavaScript['variable_logical'] = (block) => {
   const operator = (block.getFieldValue('OP') == 'AND')
         ? '&&'
         : '||'
-  const A = Blockly.JavaScript.valueToCode(block, 'A', Blockly.JavaScript.ORDER_NONE)
-  const B = Blockly.JavaScript.valueToCode(block, 'B', Blockly.JavaScript.ORDER_NONE)
+  const A = colValue(Blockly.JavaScript.valueToCode(block, 'A', Blockly.JavaScript.ORDER_NONE))
+  const B = colValue(Blockly.JavaScript.valueToCode(block, 'B', Blockly.JavaScript.ORDER_NONE))
   const code = `${A} ${operator} ${B}`
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -13,7 +13,7 @@ const dataForge = require('data-forge')
 module.paths.unshift(process.cwd())
 const TidyBlocksDataFrame = require('utilities/tb_dataframe')
 const TidyBlocksManager = require('utilities/tb_manager')
-const {registerPrefix, registerSuffix, fixCode} = require('utilities/tb_util')
+const {registerPrefix, registerSuffix, fixCode, colName, colValue} = require('utilities/tb_util')
 
 //--------------------------------------------------------------------------------
 
@@ -180,7 +180,7 @@ const Tests = {
   codeDplyrFilter: () => {
     return makeBlock(
       'dplyr_filter',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -188,7 +188,7 @@ const Tests = {
   codeDplyrGroupBy: () => {
     return makeBlock(
       'dplyr_groupby',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -197,7 +197,7 @@ const Tests = {
     return makeBlock(
       'dplyr_mutate',
       {newCol: 'newColumnName',
-       Columns: makeBlock(
+       Column: makeBlock(
          'variable_column',
          {TEXT: 'existingColumn'})})
   },
@@ -205,7 +205,7 @@ const Tests = {
   codeDplyrSelect: () => {
     return makeBlock(
       'dplyr_select',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -213,9 +213,9 @@ const Tests = {
   codeDplyrSummarize: () => {
     return makeBlock(
       'dplyr_summarize',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'stats_mean',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'existingColumn'})})})
   },
@@ -245,7 +245,7 @@ const Tests = {
   codeGgplotHist: () => {
     return makeBlock(
       'ggplot_hist',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'}),
        bins: makeBlock(
@@ -263,8 +263,8 @@ const Tests = {
          'variable_column',
          {TEXT: 'Y_axis_column'}),
        color: makeBlock(
-         'variable_text',
-         {TEXT: 'purple'}),
+         'variable_column',
+         {TEXT: 'COLOR_axis_column'}),
        lm: 'FALSE'})
   },
 
@@ -302,7 +302,7 @@ const Tests = {
   codeStatsMax: () => {
     return makeBlock(
       'stats_max',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -310,7 +310,7 @@ const Tests = {
   codeStatsMean: () => {
     return makeBlock(
       'stats_mean',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -318,7 +318,7 @@ const Tests = {
   codeStatsMedian: () => {
     return makeBlock(
       'stats_median',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -326,7 +326,7 @@ const Tests = {
   codeStatsMin: () => {
     return makeBlock(
       'stats_min',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -334,7 +334,7 @@ const Tests = {
   codeStatsSd: () => {
     return makeBlock(
       'stats_sd',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -342,7 +342,7 @@ const Tests = {
   codeStatsSum: () => {
     return makeBlock(
       'stats_sum',
-      {Columns: makeBlock(
+      {Column: makeBlock(
         'variable_column',
         {TEXT: 'existingColumn'})})
   },
@@ -396,7 +396,7 @@ const Tests = {
         {}),
       makeBlock(
         'ggplot_hist',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'Petal_Length'}),
          bins: makeBlock(
@@ -412,12 +412,12 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_select',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'Petal_Length'})}),
       makeBlock(
         'ggplot_hist',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'Petal_Length'}),
          bins: makeBlock(
@@ -433,7 +433,7 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_filter',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_compare',
           {OP: 'GT',
            A: makeBlock(
@@ -444,7 +444,7 @@ const Tests = {
              {NUM: 5.0})})}),
       makeBlock(
         'ggplot_hist',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'Petal_Length'}),
          bins: makeBlock(
@@ -460,7 +460,7 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_filter',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_compare',
           {OP: 'GTE',
            A: makeBlock(
@@ -480,7 +480,7 @@ const Tests = {
       makeBlock(
         'dplyr_mutate',
         {newCol: 'red_green',
-         Columns: makeBlock(
+         Column: makeBlock(
            'stats_arithmetic',
            {OP: 'ADD',
             A: makeBlock(
@@ -499,7 +499,7 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_select',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'blue'})})
     ]
@@ -512,9 +512,9 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_summarize',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'stats_sum',
-          {Columns: makeBlock(
+          {Column: makeBlock(
             'variable_column',
             {TEXT: 'red'})})})
     ]
@@ -527,7 +527,7 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_groupby',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'blue'})})
     ]
@@ -540,14 +540,14 @@ const Tests = {
         {}),
       makeBlock(
         'dplyr_groupby',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'variable_column',
           {TEXT: 'blue'})}),
       makeBlock(
         'dplyr_summarize',
-        {Columns: makeBlock(
+        {Column: makeBlock(
           'stats_mean',
-          {Columns: makeBlock(
+          {Column: makeBlock(
             'variable_column',
             {TEXT: 'green'})})})
     ]

--- a/utilities/tb_util.js
+++ b/utilities/tb_util.js
@@ -44,6 +44,34 @@ const fixCode = (code) => {
 }
 
 /**
+ * Get a column name from an @-prefixed column identifier.
+ * @param input {string} - column identifier prefixed with '@'.
+ * @return column name without '@'.
+ */
+const colName = (input) => {
+  if (! input.startsWith('@')) {
+    console.log('ERROR ERROR ERROR in colname', input)
+  }
+  return input.substring(1)
+}
+
+/**
+ * Get the value of a column by cases.
+ * 1. If the input isn't a string, leave it alone.
+ * 2. If the input doesn't start with '@', leave it alone.
+ * 3. If the input is '@name', convert it to 'row["name"]'.
+ */
+const colValue = (input) => {
+  if (typeof input !== 'string') {
+    return input
+  }
+  if (! input.startsWith('@')) {
+    return input
+  }
+  return `row["${colName(input)}"]`
+}
+
+/**
  * Create dynamic table from array from JSON with one table column per property.
  * Each object must have the same properties.
  * @param {JSON} json - JSON object to convert to table.
@@ -121,5 +149,5 @@ const findLineByLeastSquares = (values_x, values_y) => {
 // Make this file require'able if running from the command line.
 //
 if (typeof module !== 'undefined') {
-  module.exports = {registerPrefix, registerSuffix, fixCode}
+  module.exports = {registerPrefix, registerSuffix, fixCode, colName, colValue}
 }


### PR DESCRIPTION
This depends on #60 and #61.

`variable_column` was generating `row["name"]` for column `name`, which meant that generators above it had to strip off `row["` and `"]` in various ways. This PR takes a different approach:

1.  `variable_column` generates `@name`, where the leading `@` signals that this is a column name (and will cause an error if we try to run the code without some tidying up).
2.  The new function `colName` strips the `@` to get back to the original name, and is used in contexts where we're sure that we're not going to be dealing with something like an arithmetic expression. For example, the name of a column used in a Vega-Lite plot is always going to be a column, not an expression, because the Vega-Lite spec doesn't speak dataForge.
3.  The new function `colValue` produces code to get the value of its input string. If the string starts with `@`, then it's a column name, so we need `row["name"]`. If the string *doesn't* start with `@`, then someone else has already unmangled it, so we don't need to do anything to it. For example, in `[ADD "red" [ADD "green" "blue"]]`, the block for "red" will generate `@red`, which `colValue` will turn into `row["red"]`, while the nested addition block will generate the string `row["green"] + row["blue"]`, which doesn't have a leading `@`, so no adjustment is necessary.