### PR TITLE
transformHeader

### DIFF
--- a/blocks/variable_columns.js
+++ b/blocks/variable_columns.js
@@ -1,0 +1,12 @@
+Blockly.Blocks['variable_columns'] = {
+    init: function() {
+      this.appendValueInput("TEXT")
+          .setCheck(null)
+          .appendField(new Blockly.FieldTextInput("column"), "column");
+      this.setInputsInline(false);
+      this.setOutput(true, null);
+      this.setColour(230);
+   this.setTooltip("");
+   this.setHelpUrl("");
+    }
+  };

--- a/generators/js/variable_columns.js
+++ b/generators/js/variable_columns.js
@@ -1,0 +1,9 @@
+//
+// Represent a column name. Prefix with an '@' to indicate that it's a column
+// name; other code will then handle.
+//
+Blockly.JavaScript['variable_columns'] = (block) => {
+    const code = '@' + block.getFieldValue('TEXT')
+    return [code, Blockly.JavaScript.ORDER_ATOMIC]
+  }
+  

--- a/generators/r/stats_mean.js
+++ b/generators/r/stats_mean.js
@@ -2,9 +2,8 @@
 // Find the mean.
 //
 Blockly.R['stats_mean'] = (block) => {
-    const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
-          .replace('row.', '')
-    const code = `mean_${argColumns} = ${argColumns}`
-    return [code, Blockly.JavaScript.ORDER_NONE]
-  }
-  
+      const argColumns = Blockly.JavaScript.valueToCode(block, 'Columns', Blockly.JavaScript.ORDER_NONE)
+            .replace('row.', '')
+      const code = `mean_${argColumns} = ${argColumns}`
+      return [code, Blockly.JavaScript.ORDER_NONE]
+    }

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
             <block type="variable_number"></block>
             <block type="variable_logical"></block>
             <block type="variable_text"></block>
+            <block type="variable_columns"></block>
           </category>
         </xml>
       </div>
@@ -203,6 +204,9 @@
 
       <script src="blocks/variable_column.js"></script>
       <script src="generators/js/variable_column.js"></script>
+
+      <script src="blocks/variable_columns.js"></script>
+      <script src="generators/js/variable_columns.js"></script>
 
       <script src="blocks/variable_compare.js"></script>
       <script src="generators/js/variable_compare.js"></script>

--- a/utilities/tb_gui.js
+++ b/utilities/tb_gui.js
@@ -64,6 +64,7 @@ function runCode () {
   Blockly.JavaScript.INFINITE_LOOP_TRAP = null
   const code = fixCode(Blockly.JavaScript.workspaceToCode(DemoWorkspace))
   eval(code)
+  console.log(code)
   TidyBlocksManager.run()
 }
 

--- a/utilities/tb_util.js
+++ b/utilities/tb_util.js
@@ -11,7 +11,24 @@ const readCSV = (url) => {
     return null
   }
   else {
-    const result = Papa.parse(request.responseText, {header: true})
+    const result = Papa.parse(request.responseText, 
+        {
+          header: true,
+          dynamicTyping: true,
+          transformHeader:function(h){
+            var h = h.replace(/\/|\.|\(|\)| /g, '_').replace(/__/g, "_")
+
+            var t = h[h.length -1]
+
+            if (h[h.length -1] === "_") {
+              h = h.substring(0, h.length - 1)
+            } else {
+              h = h
+            }
+
+            return h
+          }
+        })
     return new TidyBlocksDataFrame(result.data)
   }
 }


### PR DESCRIPTION
using PapaParse's `transformHeaders` closes #31 

- replace `(` `)` `\` `.` with `_`
- if string ends with one of these characters then remove
- if there are two forbidden characters in a row replace `__` with `_`

I tried thinking up some weird use cases like a header `area (sq.mi)` to convert it to `area_sq_mi` but I was wondering if we could write some sort of test to go through permutations of these forbidden characters?