### PR TITLE
Select block: single text field

### DIFF
--- a/blocks/dplyr_select.js
+++ b/blocks/dplyr_select.js
@@ -1,20 +1,23 @@
-//
-// Visuals for select block.
-//
-Blockly.Blocks['dplyr_select'] = {
-  init: function() {
-    this
-      .appendDummyInput()
-      .appendField('Select')
-    this
-      .appendValueInput('Column')
-      .setCheck(null)
-    this.setInputsInline(true)
-    this.setPreviousStatement(true, 'Array')
-    this.setNextStatement(true, 'Array')
-    this.setNextStatement(true, null)
-    this.setTooltip('')
-    this.setHelpUrl('')
-    this.setStyle('dplyr_blocks')
+Blockly.defineBlocksWithJsonArray([
+  {
+    "type": "dplyr_select",
+    "message0": "SELECT %1 %2",
+    "args0": [
+      {
+        "type": "input_dummy"
+      },
+      {
+        "type": "field_input",
+        "name": "Column",
+        "text": "columns"
+      }
+    ],
+    "inputsInline": true,
+    "previousStatement": null,
+    "nextStatement": null,
+    "style": "dplyr_blocks",
+    "tooltip": "Select multiple columns by separating with commas",
+    "helpUrl": ""
   }
-}
+])
+

--- a/generators/js/dplyr_select.js
+++ b/generators/js/dplyr_select.js
@@ -1,7 +1,11 @@
 //
-// Select columns.
+// Select columns
 //
 Blockly.JavaScript['dplyr_select'] = (block) => {
-  const argColumn = colName(Blockly.JavaScript.valueToCode(block, 'Column', Blockly.JavaScript.ORDER_NONE))
-  return `.subset(["${argColumn}"])`
+  const argColumn = commaSeperate(block.getFieldValue('Column'))
+  const code = `.subset(["${argColumn}"])`
+
+  console.log(argColumn)
+  console.log(code)
+  return code
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3471,8 +3471,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3490,13 +3489,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3509,18 +3506,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3623,8 +3617,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3634,7 +3627,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3647,20 +3639,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3677,7 +3666,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3750,8 +3738,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3761,7 +3748,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3837,8 +3823,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3868,7 +3853,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3886,7 +3870,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3925,13 +3908,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/utilities/tb_codegen.js
+++ b/utilities/tb_codegen.js
@@ -41,6 +41,17 @@ const colName = (input) => {
 }
 
 /**
+ * Within the select block we need to place perentheses 
+ * arround the comma seperate values
+ * 
+ */
+const commaSeperate = (input)  => {
+  input = `${input.replace(/ /g,'')
+                  .replace(/,/g, "\",\"")}`
+  return input
+}
+
+/**
  * Get the value of a column by cases.
  * 1. If the input isn't a string, leave it alone.
  * 2. If the input doesn't start with '@', leave it alone.


### PR DESCRIPTION
- rather then input the `column` block, the `select` block uses the newly created commaSeperate function
- the `commaSeperate` function takes the string input `red, blue` and detects white space then adds appropriate quotations 