### PR TITLE
Checking block field  names in unit tests.

### DIFF
--- a/blocks/value_number.js
+++ b/blocks/value_number.js
@@ -7,7 +7,7 @@ Blockly.defineBlocksWithJsonArray([
     message0: '%1',
     args0: [{
       type: 'field_number',
-      name: 'NUM',
+      name: 'VALUE',
       value: 0
     }],
     output: 'Number',

--- a/blocks/value_text.js
+++ b/blocks/value_text.js
@@ -8,7 +8,7 @@ Blockly.defineBlocksWithJsonArray([
     args0: [
       {
         type: 'field_input',
-        name: 'TEXT',
+        name: 'VALUE',
         text: 'text'
       }
     ],

--- a/generators/js/value_number.js
+++ b/generators/js/value_number.js
@@ -2,7 +2,7 @@
 // Create code for numeric constant block.
 //
 Blockly.JavaScript['value_number'] = (block) => {
-  const value = parseFloat(block.getFieldValue('NUM'))
+  const value = parseFloat(block.getFieldValue('VALUE'))
   const order = (value >= 0)
         ? Blockly.JavaScript.ORDER_ATOMIC
         : Blockly.JavaScript.ORDER_UNARY_NEGATION

--- a/generators/js/value_text.js
+++ b/generators/js/value_text.js
@@ -2,7 +2,7 @@
 // Create code for text constant block.
 //
 Blockly.JavaScript['value_text'] = (block) => {
-  const value = Blockly.JavaScript.quote_(block.getFieldValue('VALUE'))
-  const code = `(row) => ${value}`
+  const text = Blockly.JavaScript.quote_(block.getFieldValue('VALUE'))
+  const code = `(row) => ${text}`
   return [code, Blockly.JavaScript.ORDER_ATOMIC]
 }

--- a/tests/test_js_codegen.js
+++ b/tests/test_js_codegen.js
@@ -301,8 +301,7 @@ describe('generate code for single blocks', () => {
          {COLUMN: 'Y_axis_column'}),
        COLOR: makeBlock(
          'value_column',
-         {COLUMN: 'COLOR_axis_column'}),
-       lm: 'FALSE'})
+         {COLUMN: 'COLOR_axis_column'})})
     const code = generateCode(pipeline)
     assert_includes(code, '.plot(displayTable, displayPlot',
                     'pipeline does not call .plot')
@@ -365,7 +364,7 @@ describe('generate code for single blocks', () => {
   it('generates code to do logical negation', (done) => {
     const pipeline = makeBlock(
       'value_not',
-      {LEFT: makeBlock(
+      {VALUE: makeBlock(
         'value_column',
         {COLUMN: 'existing'})})
     const code = generateCode(pipeline)
@@ -429,7 +428,7 @@ describe('generate code for single blocks', () => {
   it('generates the code for a number', (done) => {
     const pipeline = makeBlock(
       'value_number',
-      {NUM: 3.14})
+      {VALUE: 3.14})
     const code = generateCode(pipeline)
     assert.equal(code, '(row) => (3.14)',
                  'pipeline does not generate expected number')

--- a/tests/test_js_error.js
+++ b/tests/test_js_error.js
@@ -36,8 +36,7 @@ describe('raises errors at the right times', () => {
 
   it('raises an error when constructing a block with an empty column name', (done) => {
     assert.throws(() => makeBlock('value_column',
-                                  {TEXT: ''}),
-                  /Empty column name/)
+                                  {COLUMN: ''}))
     done()
   })
 
@@ -48,7 +47,7 @@ describe('raises errors at the right times', () => {
         {}),
       makeBlock(
         'transform_mutate',
-        {NEW_COLUMN: 'should_fail',
+        {COLUMN: 'should_fail',
          VALUE: makeBlock(
            'value_arithmetic',
            {OP: 'ADD',
@@ -57,7 +56,7 @@ describe('raises errors at the right times', () => {
               {COLUMN: 'nonexistent'}),
             RIGHT: makeBlock(
               'value_number',
-              {NUM: 0})})})
+              {VALUE: 0})})})
     ]
     const code = evalCode(pipeline)
     assert.notEqual(Result.error, null,

--- a/tests/test_js_exec.js
+++ b/tests/test_js_exec.js
@@ -190,7 +190,7 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'red'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 0})})})
+             {VALUE: 0})})})
     ]
     evalCode(pipeline)
     assert.equal(Result.table.length, 5,
@@ -213,7 +213,7 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'red'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 0})})}),
+             {VALUE: 0})})}),
       makeBlock(
         'plumbing_notify',
         {NAME: 'left'})
@@ -243,15 +243,15 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'Petal_Length'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 5.0})})}),
+             {VALUE: 5.0})})}),
       makeBlock(
         'plot_hist',
-        {Column: makeBlock(
+        {COLUMN: makeBlock(
           'value_column',
           {COLUMN: 'Petal_Length'}),
          BINS: makeBlock(
            'value_number',
-           {NUM: 20})})
+           {VALUE: 20})})
     ]
     evalCode(pipeline)
     assert.equal(Object.keys(Result.table[0]).length, 5,
@@ -474,7 +474,7 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'red'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 0})})}),
+             {VALUE: 0})})}),
       makeBlock(
         'plumbing_notify',
         {NAME: 'left'}),
@@ -493,7 +493,7 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'green'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 0})})}),
+             {VALUE: 0})})}),
       makeBlock(
         'plumbing_notify',
         {NAME: 'right'}),
@@ -515,7 +515,7 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'left_blue'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 0})})}),
+             {VALUE: 0})})}),
       makeBlock(
         'transform_filter',
         {TEST: makeBlock(
@@ -526,7 +526,7 @@ describe('execute blocks for entire pipelines', () => {
              {COLUMN: 'right_blue'}),
            RIGHT: makeBlock(
              'value_number',
-             {NUM: 0})})})
+             {VALUE: 0})})})
     ]
     evalCode(pipeline)
     assert.deepEqual(Result.table,

--- a/tests/test_js_utils.js
+++ b/tests/test_js_utils.js
@@ -115,7 +115,7 @@ describe('blocks are given IDs and can be looked up', () => {
         {}),
       makeBlock(
         'transform_mutate',
-        {NEW_COLUMN: 'should_fail',
+        {COLUMN: 'should_fail',
          VALUE: makeBlock(
            'value_arithmetic',
            {OP: 'ADD',
@@ -124,7 +124,7 @@ describe('blocks are given IDs and can be looked up', () => {
               {COLUMN: 'nonexistent'}),
             RIGHT: makeBlock(
               'value_number',
-              {NUM: 0})})})
+              {VALUE: 0})})})
     ]
     assert.equal(TidyBlocksManager.getNumBlocks(), 5,
                  'Wrong number of blocks recorded')


### PR DESCRIPTION
1.  Modify `Blockly` to be a proper singleton class.
2.  Have all block types register their fields when loaded.
3.  Check given fields against expected fields when creating mock blocks.
4.  Fix tests that were using field names that aren't there any more.