### PR TITLE
Checking types of columns

### DIFF
--- a/blocks/value_type.js
+++ b/blocks/value_type.js
@@ -1,0 +1,29 @@
+//
+// Visuals for type checking block.
+//
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'value_type',
+    message0: '%1 is %2 ?',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'VALUE'
+      },
+      {
+        type: 'field_dropdown',
+        name: 'TYPE',
+        options: [
+          ['boolean', 'tbIsBoolean'],
+          ['number', 'tbIsNumber'],
+          ['string', 'tbIsString']
+        ]
+      }
+    ],
+    inputsInline: true,
+    output: 'Boolean',
+    style: 'value_blocks',
+    tooltip: 'check the datatype of a value',
+    helpUrl: ''
+  }
+])

--- a/generators/js/value_type.js
+++ b/generators/js/value_type.js
@@ -1,0 +1,10 @@
+//
+// Implement type checking.
+//
+Blockly.JavaScript['value_type'] = (block) => {
+  const type = block.getFieldValue('TYPE')
+  const order = Blockly.JavaScript.ORDER_NONE
+  const value = Blockly.JavaScript.valueToCode(block, 'VALUE', order)
+  const code = `(row) => ${type}(row, ${value})`
+  return [code, order]
+}

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
             <block type="value_number"></block>
             <block type="value_logical"></block>
             <block type="value_text"></block>
+            <block type="value_type"></block>
           </category>
         </xml>
       </div>
@@ -217,6 +218,9 @@
 
       <script src="blocks/value_text.js"></script>
       <script src="generators/js/value_text.js"></script>
+
+      <script src="blocks/value_type.js"></script>
+      <script src="generators/js/value_type.js"></script>
     </div>
 
     <!-- R code

--- a/tests/test_js_exec.js
+++ b/tests/test_js_exec.js
@@ -518,6 +518,48 @@ describe('execute blocks for entire pipelines', () => {
     done()
   })
 
+  it('checks data types correctly', (done) => {
+    const pipeline = [
+      makeBlock(
+        'data_colors',
+        {}),
+      makeBlock(
+        'transform_mutate',
+        {COLUMN: 'result_name_string',
+         VALUE: makeBlock(
+           'value_type',
+           {TYPE: 'tbIsString',
+            VALUE: makeBlock(
+              'value_column',
+              {COLUMN: 'name'})})}),
+      makeBlock(
+        'transform_mutate',
+        {COLUMN: 'result_red_string',
+         VALUE: makeBlock(
+           'value_type',
+           {TYPE: 'tbIsString',
+            VALUE: makeBlock(
+              'value_column',
+              {COLUMN: 'red'})})}),
+      makeBlock(
+        'transform_mutate',
+        {COLUMN: 'result_green_number',
+         VALUE: makeBlock(
+           'value_type',
+           {TYPE: 'tbIsNumber',
+            VALUE: makeBlock(
+              'value_column',
+              {COLUMN: 'green'})})})
+    ]
+    const code = evalCode(pipeline)
+    assert(Result.table.every(row => row.result_name_string),
+           `Expected all names to be strings`)
+    assert(Result.table.every(row => !row.result_red_string),
+           `Expected all red values to not be strings`)
+    assert(Result.table.every(row => row.result_green_number),
+           `Expected all green values to be strings`)
+    done()
+  })
 })
 
 describe('check that specific bugs have been fixed', () => {

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -103,7 +103,7 @@ const tbAssert = (check, message) => {
  * @param value What to check.
  * @returns The input value if it passes the test.
  */
-const tbIsNumber = (value) => {
+const tbAssertNumber = (value) => {
   tbAssert(typeof value === 'number',
            `Value ${value} is not a number`)
   return value
@@ -257,6 +257,38 @@ const tbToString = (row, getValue) => {
 //--------------------------------------------------------------------------------
 
 /**
+ * Check if value is Boolean.
+ * @param {Object} row Row containing values.
+ * @param {function} getValue How to get desired value.
+ * @returns Is value Boolean?
+ */
+const tbIsBoolean = (row, getValue) => {
+  return typeof getValue(row) === 'boolean'
+}
+
+/**
+ * Check if value is number.
+ * @param {Object} row Row containing values.
+ * @param {function} getValue How to get desired value.
+ * @returns Is value numeric?
+ */
+const tbIsNumber = (row, getValue) => {
+  return typeof getValue(row) === 'number'
+}
+
+/**
+ * Check if value is string.
+ * @param {Object} row Row containing values.
+ * @param {function} getValue How to get desired value.
+ * @returns Is value string?
+ */
+const tbIsString = (row, getValue) => {
+  return typeof getValue(row) === 'string'
+}
+
+//--------------------------------------------------------------------------------
+
+/**
  * Get a column's value from a row, failing if the column doesn't exist.
  * @param {Object} row The row to look in.
  * @param {string} key The field to look up.
@@ -276,8 +308,8 @@ const tbGet = (row, key) => {
  * @returns The sum.
  */
 const tbAdd = (row, getLeft, getRight) => {
-  const left = tbIsNumber(getLeft(row))
-  const right = tbIsNumber(getRight(row))
+  const left = tbAssertNumber(getLeft(row))
+  const right = tbAssertNumber(getRight(row))
   return left + right
 }
 
@@ -289,8 +321,8 @@ const tbAdd = (row, getLeft, getRight) => {
  * @returns The quotient.
  */
 const tbDiv = (row, getLeft, getRight) => {
-  const left = tbIsNumber(getLeft(row))
-  const right = tbIsNumber(getRight(row))
+  const left = tbAssertNumber(getLeft(row))
+  const right = tbAssertNumber(getRight(row))
   return left / right
 }
 
@@ -302,8 +334,8 @@ const tbDiv = (row, getLeft, getRight) => {
  * @returns The exponentiated value.
  */
 const tbExp = (row, getLeft, getRight) => {
-  const left = tbIsNumber(getLeft(row))
-  const right = tbIsNumber(getRight(row))
+  const left = tbAssertNumber(getLeft(row))
+  const right = tbAssertNumber(getRight(row))
   return left ** right
 }
 
@@ -315,8 +347,8 @@ const tbExp = (row, getLeft, getRight) => {
  * @returns The remainder.
  */
 const tbMod = (row, getLeft, getRight) => {
-  const left = tbIsNumber(getLeft(row))
-  const right = tbIsNumber(getRight(row))
+  const left = tbAssertNumber(getLeft(row))
+  const right = tbAssertNumber(getRight(row))
   return left * right
 }
 
@@ -328,8 +360,8 @@ const tbMod = (row, getLeft, getRight) => {
  * @returns The product.
  */
 const tbMul = (row, getLeft, getRight) => {
-  const left = tbIsNumber(getLeft(row))
-  const right = tbIsNumber(getRight(row))
+  const left = tbAssertNumber(getLeft(row))
+  const right = tbAssertNumber(getRight(row))
   return left % right
 }
 
@@ -340,7 +372,7 @@ const tbMul = (row, getLeft, getRight) => {
  * @returns The numerical negation.
  */
 const tbNeg = (row, getValue) => {
-  const value = tbIsNumber(getValue(row))
+  const value = tbAssertNumber(getValue(row))
   return - value
 }
 
@@ -352,8 +384,8 @@ const tbNeg = (row, getValue) => {
  * @returns The difference.
  */
 const tbSub = (row, getLeft, getRight) => {
-  const left = tbIsNumber(getLeft(row))
-  const right = tbIsNumber(getRight(row))
+  const left = tbAssertNumber(getLeft(row))
+  const right = tbAssertNumber(getRight(row))
   return left - right
 }
 


### PR DESCRIPTION
1. Added new block `value_type` to check if values are numbers, strings, or Booleans.
2. Implemented `tbIsNumber`, `tbIsString`, and `tbIsBoolean`.
3. Changed name of old `tbIsNumber` function to `tbAssertNumber` to avoid conflict.

To Do: after #160 is merged, add checking for datetime.

This block will allow users to use if-else to convert only a subset of values from one type to another.