### PR TITLE
Adding a date parser.

### DIFF
--- a/blocks/value_parsedate.js
+++ b/blocks/value_parsedate.js
@@ -1,0 +1,27 @@
+//
+// Visuals for date parsing block.
+//
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'value_parseDate',
+    message0: 'Parse date %1 as %2',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'VALUE'
+      },
+      {
+        type: 'field_input',
+        name: 'FORMAT',
+        text: 'format'
+      }
+    ],
+    inputsInline: true,
+    previousStatement: null,
+    nextStatement: null,
+    style: 'value_blocks',
+    tooltip: 'parse date according to YYYY-MM-DD style format',
+    helpUrl: '',
+    extensions: ['validate_COLUMN']
+  }
+])

--- a/generators/js/value_parsedate.js
+++ b/generators/js/value_parsedate.js
@@ -1,0 +1,8 @@
+//
+// Parse date using format.
+//
+Blockly.JavaScript['value_parseDate'] = (block) => {
+  const format = Blockly.JavaScript.quote_(block.getFieldValue('FORMAT'))
+  const value = Blockly.JavaScript.valueToCode(block, 'VALUE', Blockly.JavaScript.ORDER_NONE)
+  return `(row) => tbParseDate(${block.tbId}, row, ${format}, ${value})`
+}

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
             <block type="value_not"></block>
             <block type="value_number"></block>
             <block type="value_logical"></block>
+            <block type="value_parseDate"></block>
             <block type="value_text"></block>
             <block type="value_type"></block>
           </category>
@@ -108,6 +109,7 @@
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@3.3.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@4.2.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.0.2/papaparse.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.min.js"></script>
 
     <!-- Put all blocks code in a div so it's easy to find and load for testing. -->
     <div id="tidyblocks">
@@ -219,6 +221,9 @@
 
       <script src="blocks/value_logical.js"></script>
       <script src="generators/js/value_logical.js"></script>
+
+      <script src="blocks/value_parseDate.js"></script>
+      <script src="generators/js/value_parseDate.js"></script>
 
       <script src="blocks/value_text.js"></script>
       <script src="generators/js/value_text.js"></script>

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -629,6 +629,33 @@ describe('execute blocks for entire pipelines', () => {
     done()
   })
 
+  it('converts strings to dates', (done) => {
+    const pipeline = [
+      makeBlock(
+        'data_single',
+        {}),
+      makeBlock(
+        'transform_mutate',
+        {COLUMN: 'epoch',
+         VALUE: makeBlock(
+           'value_text',
+           {VALUE: '1970-01-01'})}),
+      makeBlock(
+        'transform_mutate',
+        {COLUMN: 'recovered',
+         VALUE: makeBlock(
+           'value_parseDate',
+           {VALUE: makeBlock(
+             'value_column',
+             {COLUMN: 'epoch'}),
+            FORMAT: 'YYYY-MM-DD'})})
+    ]
+    const env = evalCode(pipeline)
+    assert(env.table[0].recovered instanceof Date,
+           `Expected date, not ${typeof env.table[0].recovered}`)
+    done()
+  })
+
 })
 
 describe('check that specific bugs have been fixed', () => {

--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -8,6 +8,7 @@ const MULTIPLE_COLUMN_NAMES = /^ *([_A-Za-z][_A-Za-z0-9]*)( *, *[_A-Za-z][_A-Za-
 // Names of single-column fields in various blocks (for generating validators).
 const SINGLE_COLUMN_FIELDS = [
   'COLUMN',
+  'FORMAT',
   'LEFT_TABLE',
   'LEFT_COLUMN',
   'RIGHT_TABLE',

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -308,6 +308,21 @@ const tbIsString = (row, getValue) => {
 //--------------------------------------------------------------------------------
 
 /*
+ * Convert string to date object using format.
+ * @param {number} rowId The ID of the block.
+ * @param {Object} row Row containing values.
+ * @param {string} format Format to use for parsing (FIXME: IGNORED UNTIL WE CAN LOAD 'moment').
+ * @param {function} getValue How to get desired value.
+ * @returns Date corresponding to string.
+ */
+const tbParseDate = (rowId, row, format, getValue) => {
+  const value = getValue(row)
+  tbAssert(typeof value === 'string',
+           `Expected string not ${typeof value}`)
+  return new Date(value)
+}
+
+/*
  * Extract year from value.
  * @param {Object} row Row containing values.
  * @param {function} getValue How to get desired value.


### PR DESCRIPTION
1.  New block.
2.  Only uses `Date(string)` - should use the `moment` library, but that would introduce a Node dependency into `tidyblocks/tidyblocks.js`, which so far we've managed to avoid.