### PR TITLE
Handling the case of empty results in summarize

### DIFF
--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -656,6 +656,69 @@ describe('execute blocks for entire pipelines', () => {
     done()
   })
 
+  it('counts rows correctly', (done) => {
+    const pipeline = [
+      makeBlock(
+        'data_double',
+        {}),
+      makeBlock(
+        'transform_summarize',
+        {FUNC: 'tbCount',
+         COLUMN: 'first'})
+    ]
+    const env = evalCode(pipeline)
+    assert(env.table.length == 1,
+           `Expect a single row of output`)
+    assert(env.table[0].first == 2,
+           `Expected a count of 2, not ${env.table[0].first}`)
+    done()
+  })
+
+  it('calculates the maximum value correct', (done) => {
+    const pipeline = [
+      makeBlock(
+        'data_double',
+        {}),
+      makeBlock(
+        'transform_summarize',
+        {FUNC: 'tbMax',
+         COLUMN: 'second'})
+    ]
+    const env = evalCode(pipeline)
+    assert(env.table.length == 1,
+           `Expect a single row of output`)
+    assert(env.table[0].second == 200,
+           `Expected a max of 200, not ${env.table[0].second}`)
+    done()
+  })
+
+  it('handles empty tables correctly when calculating maxima', (done) => {
+    const pipeline = [
+      makeBlock(
+        'data_colors',
+        {}),
+      makeBlock(
+        'transform_filter',
+        {TEST: makeBlock(
+          'value_compare',
+          {OP: 'tbLt',
+           LEFT: makeBlock(
+             'value_column',
+             {COLUMN: 'red'}),
+           RIGHT: makeBlock(
+             'value_number',
+             {VALUE: 0})})}),
+      makeBlock(
+        'transform_summarize',
+        {FUNC: 'tbMax',
+         COLUMN: 'red'})
+    ]
+    const env = evalCode(pipeline)
+    assert(env.table.length == 0,
+           `Expected empty output`)
+    done()
+  })
+
 })
 
 describe('check that specific bugs have been fixed', () => {

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -807,11 +807,18 @@ class TidyBlocksDataFrame {
    * @return A new dataframe.
    */
   summarize (blockId, func, column) {
+    // Handle empty case.
+    if (this.data.length === 0) {
+      return new TidyBlocksDataFrame([])
+    }
+
+    // Check column access.
     tbAssert(column,
              `[block ${blockId}] no column specified for summarize`)
     tbAssert(this.hasColumns(column),
              `[block ${blockId}] unknown column(s) [${column}] in summarize`)
 
+    // Final data.
     const result = []
 
     // Aggregate the whole thing?


### PR DESCRIPTION
1. Adding some tests to improve code coverage.
2. Handling the case of empty tables when summarizing.

This is only a partial solution: we lose all column information when a result table is empty.