### PR TITLE
Column names

### DIFF
--- a/test/test_js_utils.js
+++ b/test/test_js_utils.js
@@ -148,7 +148,7 @@ describe('blocks return proper this.columns', () => {
         {COLUMN: 'first'})
     ]
     const env = evalCode(pipeline)
-    assert(env.table[0].hasOwnProperty('_group_')) // check for _group_ column
+    assert('_group_' in env.table[0]) // check for _group_ column
     done()
   })
 
@@ -165,38 +165,28 @@ describe('blocks return proper this.columns', () => {
         {})
     ]
     const env = evalCode(pipeline)
-    assert(env.table[0].hasOwnProperty('_group_') === false) // check _group_ column removed
+    assert(!('_group_' in env.table[0])) // check _group_ column removed
     done()
-  })
+ })
 
   // FIXME evaluating to falsey when true
-  it('sort this.columns unchanged', (done) => {
+  it('sorting does not change this.columns', (done) => {
     // original dataframe
-    const pipeline_iris = [
+    const pipeline = [
       makeBlock(
       'data_iris',
       {})
     ]
-    // sorted dataframe
-    const pipeline_sort = [
-      makeBlock(
-        'data_iris',
-        {}),
-      makeBlock(
-        'transform_sort',
-        {MULTIPLE_COLUMNS: 'Sepal_Length',
-         DESCENDING: 'false'})
-    ]
-    const env_iris = evalCode(pipeline_iris)
-    const env_sort = evalCode(pipeline_sort)
-    // console.log(Object.keys(env_iris.table[0]))
-    // console.log(Object.keys(env_sort.table[0]))
-    // compare pipeline columns
-    assert(Object.keys(env_iris.table[0]) == Object.keys(env_sort.table[0]))
+    const env_iris = evalCode(pipeline)
+    pipeline.push(makeBlock(
+          'transform_sort',
+          {MULTIPLE_COLUMNS: 'Sepal_Length',
+           DESCENDING: 'false'}))
+    const env_sort = evalCode(pipeline)
+    assert.deepStrictEqual(Object.keys(env_iris.table[0]), Object.keys(env_sort.table[0]))
     done()
   })
 
-  // FIXME Also evaluating to falsy when true!
   it('select returns only selected column', (done) => {
     const pipeline = [
       makeBlock(
@@ -204,11 +194,10 @@ describe('blocks return proper this.columns', () => {
         {}),
       makeBlock(
         'transform_select',
-        {MULTIPLE_COLUMNS: ['Sepal_Length']})
+        {MULTIPLE_COLUMNS: 'Sepal_Length'})
     ]
     const env = evalCode(pipeline)
-    console.log(env)
-    assert(Object.keys(env.table[0]) === [ 'Sepal_Length' ])
+    assert.deepStrictEqual(Object.keys(env.table[0]), [ 'Sepal_Length'])
     done()
   })
 
@@ -226,7 +215,7 @@ describe('blocks return proper this.columns', () => {
            {VALUE: 0})})
     ]
     const env = evalCode(pipeline)
-    assert(env.table[0].hasOwnProperty('newColumnName'))
+    assert('newColumnName' in env.table[0])
     done()
   }
 

--- a/test/test_js_utils.js
+++ b/test/test_js_utils.js
@@ -215,6 +215,7 @@ describe('blocks return proper this.columns', () => {
            {VALUE: 0})})
     ]
     const env = evalCode(pipeline)
+    console.log(env)
     assert('newColumnName' in env.table[0])
     done()
   }

--- a/test/test_js_utils.js
+++ b/test/test_js_utils.js
@@ -201,6 +201,33 @@ describe('blocks return proper this.columns', () => {
     done()
   })
 
+
+   // Is this testing what we want it to? 
+   // Does this cover use cases?
+   it('filter does not change columns'), (done) => {
+    const pipeline = [
+      makeBlock('data_iris',
+      {})
+    ]
+    env_iris = evalCode(pipeline)
+      // make mutate block with child block value_number = 0
+      pipeline.push(makeBlock(
+        'transform_filter',
+        {TEST: makeBlock(
+          'value_compare',
+          {OP: 'tbEq',
+           LEFT: makeBlock(
+             'value_column',
+             {COLUMN: 'Species'}),
+           RIGHT: makeBlock(
+             'value_text',
+             {COLUMN: 'Setosa'})})}))
+    const env_filter = evalCode(pipeline)
+    console.log(env)
+    assert.deepStrictEqual(Object.keys(env_iris.table[0]), Object.keys(env_filter.table[0]))
+    done()
+  }
+
   // FIXME why doesn't this work
   it('mutate adds newly named column'), (done) => {
     const pipeline = [

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -1088,6 +1088,7 @@ class TidyBlocksManagerClass {
         throw new Error('pipeline does not have a valid start block')
       }
       code = fixCode(code)
+      console.log(code)
       eval(code)
       while (this.queue.length > 0) {
         const func = this.queue.shift()


### PR DESCRIPTION
Closes #182 

New `describe` category in utils.js to look for `this.columns` (in testing `env.table`)

DONE:
- `groupBy` returns `_group_` column
- `ungroup` removes `_group_` column
- `sort` does not change columns
- `select` returns only selected columns

IN PROGRESS:
- FIXME `mutate` returns all columns + new column [Currently returns `pending` ??]
- FIXME `filter` returns `pending` -- want to discuss all use cases
- TODO `summarize`
- TODO `join`
- TODO `hasColumns`

# Questions: 

> If `this.data` is empty objects, `this.columns` is empty

What does this look like and how do we create a test for this? 

> filter doesn't change columns

Is an example of this filtering to the point where no observations of that column exist [ie: remove all cases of `red` in `data_colors`]? What is the desired outcome? Remove the column? Or add 'undefined' for that column?

> `hasColumns` tests a string or every string in a list against `this.columns`

Do you mean within the actual function to give some boolean if they're the same or not or write a unit test to make sure they're always the same?