### PR TITLE
adding assert to readCSV

### DIFF
--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -48,6 +48,10 @@ class GuiEnvironment {
    * @param {string} url URL to read from.
    */
   readCSV (url) {
+
+    tbAssert((url !== "url") && (url.length > 0),
+    `Cannot fetch empty URL`)
+
     const request = new XMLHttpRequest()
     request.open('GET', url, false)
     request.send(null)


### PR DESCRIPTION
Fixes #164 Because default text in the url input field is 'url' we need to specify this is not null and not equal to "url".

    tbAssert((url !== "url") && (url.length > 0),
    `Cannot fetch empty URL`)