### PR TITLE
Handling 3 or more summarize blocks.

### DIFF
--- a/generators/js/transform_summarize.js
+++ b/generators/js/transform_summarize.js
@@ -3,6 +3,6 @@
 //
 Blockly.JavaScript['transform_summarize'] = (block) => {
   const branch = Blockly.JavaScript.statementToCode(block, "COLUMN_FUNC_PAIR")
-        .replace('][', '], [')
+        .replace(/\]\[/g, '], [')
   return `.summarize(${block.tbId}, ${branch})`
 }

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -749,6 +749,9 @@ describe('check that grouping and summarization work', () => {
                      COLUMN: 'first'}),
           makeBlock('transform_summarize_item',
                     {FUNC: 'tbMean',
+                     COLUMN: 'second'}),
+          makeBlock('transform_summarize_item',
+                    {FUNC: 'tbMax',
                      COLUMN: 'second'})
         ]})
     ]
@@ -759,6 +762,8 @@ describe('check that grouping and summarization work', () => {
            `Expected a min of 1, not ${env.table[0].first}`)
     assert(env.table[0].second_mean == 150,
            `Expected a mean of 150, not ${env.table[0].second}`)
+    assert(env.table[0].second_max == 200,
+           `Expected a max of 200, not ${env.table[0].second}`)
     done()
   })
 


### PR DESCRIPTION
Was using string.replace, which only replaces the first occurrence - now using regular expression.

Closes #196.