### PR TITLE
Making code more consistent and increasing coverage.

### DIFF
--- a/blocks/value_convert_datetime.js
+++ b/blocks/value_convert_datetime.js
@@ -1,0 +1,33 @@
+//
+// Visuals for datetime extraction block.
+//
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'value_convert_datetime',
+    message0: '%1 date/time %2',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'VALUE'
+      },
+      {
+        type: 'field_dropdown',
+        name: 'TYPE',
+        options: [
+          ['year', 'tbToYear'],
+          ['month', 'tbToMonth'],
+          ['day', 'tbToDay'],
+          ['weekday', 'tbToWeekDay'],
+          ['hours', 'tbToHours'],
+          ['minutes', 'tbToMinutes'],
+          ['seconds', 'tbToSeconds']
+        ]
+      }
+    ],
+    inputsInline: true,
+    output: 'Number',
+    style: 'value_blocks',
+    tooltip: 'change the datatype of a value',
+    helpUrl: ''
+  }
+])

--- a/blocks/value_datetime.js
+++ b/blocks/value_datetime.js
@@ -1,33 +1,17 @@
 //
-// Visuals for datetime function block.
+// Visuals for datetime block.
 //
-Blockly.defineBlocksWithJsonArray([
+Blockly.defineBlocksWithJsonArray([ 
   {
     type: 'value_datetime',
-    message0: '%1 date/time %2',
-    args0: [
-      {
-        type: 'input_value',
-        name: 'VALUE'
-      },
-      {
-        type: 'field_dropdown',
-        name: 'TYPE',
-        options: [
-          ['year', 'tbToYear'],
-          ['month', 'tbToMonth'],
-          ['day', 'tbToDay'],
-          ['weekday', 'tbToWeekDay'],
-          ['hours', 'tbToHours'],
-          ['minutes', 'tbToMinutes'],
-          ['seconds', 'tbToSeconds']
-        ]
-      }
-    ],
-    inputsInline: true,
-    output: 'Number',
+    message0: '%1',
+    args0: [{
+      type: 'field_input',
+      name: 'VALUE',
+      value: '1970-01-01'
+    }],
+    helpUrl: '',
     style: 'value_blocks',
-    tooltip: 'change the datatype of a value',
-    helpUrl: ''
+    tooltip: 'constant date/time'
   }
 ])

--- a/blocks/value_type.js
+++ b/blocks/value_type.js
@@ -15,7 +15,7 @@ Blockly.defineBlocksWithJsonArray([
         name: 'TYPE',
         options: [
           ['boolean', 'tbIsBoolean'],
-          ['date', 'tbIsDate'],
+          ['date', 'tbIsDateTime'],
           ['missing', 'tbIsMissing'],
           ['number', 'tbIsNumber'],
           ['string', 'tbIsString']

--- a/generators/js/value_convert_datetime.js
+++ b/generators/js/value_convert_datetime.js
@@ -1,0 +1,10 @@
+//
+// Implement date/time extraction.
+//
+Blockly.JavaScript['value_convert_datetime'] = (block) => {
+  const type = block.getFieldValue('TYPE')
+  const order = Blockly.JavaScript.ORDER_NONE
+  const value = Blockly.JavaScript.valueToCode(block, 'VALUE', order)
+  const code = `(row) => ${type}(row, ${value})`
+  return [code, order]
+}

--- a/generators/js/value_datetime.js
+++ b/generators/js/value_datetime.js
@@ -1,10 +1,8 @@
 //
-// Implement date/time extraction.
+// Create code for constant date/time block.
 //
 Blockly.JavaScript['value_datetime'] = (block) => {
-  const type = block.getFieldValue('TYPE')
-  const order = Blockly.JavaScript.ORDER_NONE
-  const value = Blockly.JavaScript.valueToCode(block, 'VALUE', order)
-  const code = `(row) => ${type}(row, ${value})`
-  return [code, order]
+  const value = Blockly.JavaScript.quote_(block.getFieldValue('VALUE'))
+  const code = `(row) => new Date(${value})`
+  return [code, Blockly.JavaScript.ORDER_ATOMIC]
 }

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
             <block type="value_column"></block>
             <block type="value_compare"></block>
             <block type="value_convert"></block>
+            <block type="value_convert_datetime"></block>
             <block type="value_datetime"></block>
             <block type="value_ifElse"></block>
             <block type="value_negate"></block>
@@ -209,6 +210,9 @@
 
       <script src="blocks/value_convert.js"></script>
       <script src="generators/js/value_convert.js"></script>
+
+      <script src="blocks/value_convert_datetime.js"></script>
+      <script src="generators/js/value_convert_datetime.js"></script>
 
       <script src="blocks/value_datetime.js"></script>
       <script src="generators/js/value_datetime.js"></script>

--- a/test/test_js_codegen.js
+++ b/test/test_js_codegen.js
@@ -123,14 +123,14 @@ describe('generate code for single blocks', () => {
   it('generates code to convert types', (done) => {
     const pipeline = makeBlock(
       'value_convert',
-      {TYPE: 'tbToString',
+      {TYPE: 'tbToText',
        VALUE: makeBlock(
          'value_column',
          {COLUMN: 'left'})})
     const code = generateCode(pipeline)
     assert_startsWith(code, '(row) =>',
                       'generated code does not appear to be a function')
-    assert_includes(code, 'tbToString',
+    assert_includes(code, 'tbToText',
                     'Generated code does not start with correct function')
     done()
   })

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -314,9 +314,9 @@ const tbToNumber = (blockId, row, getValue) => {
  * @param {number{ blockId which block this is.
  * @param {Object} row Row containing values.
  * @param {function} getValue How to get desired value.
- * @returns String value.
+ * @returns Text value.
  */
-const tbToString = (blockId, row, getValue) => {
+const tbToText = (blockId, row, getValue) => {
   let value = getValue(row)
   if (value === MISSING) {
     // keep as is
@@ -341,13 +341,13 @@ const tbIsBoolean = (blockId, row, getValue) => {
 }
 
 /**
- * Check if value is a date.
+ * Check if value is a datetime.
  * @param {number} blockId The ID of the block.
  * @param {Object} row Row containing values.
  * @param {function} getValue How to get desired value.
  * @returns Is value numeric?
  */
-const tbIsDate = (blockId, row, getValue) => {
+const tbIsDateTime = (blockId, row, getValue) => {
   return getValue(row) instanceof Date
 }
 
@@ -378,9 +378,9 @@ const tbIsNumber = (blockId, row, getValue) => {
  * @param {number} blockId The ID of the block.
  * @param {Object} row Row containing values.
  * @param {function} getValue How to get desired value.
- * @returns Is value string?
+ * @returns Is value text?
  */
-const tbIsString = (blockId, row, getValue) => {
+const tbIsText = (blockId, row, getValue) => {
   return typeof getValue(row) === 'string'
 }
 


### PR DESCRIPTION
1.  More tests.
2.  Rename `value_datetime` to `value_convert_datetime` (since it's a type conversion function).
3.  Created new `value_datetime` for entering a constant date/time.
4.  Use `text` instead of `string` when naming things.