### PR TITLE
Storing column names separately in dataframe.

### DIFF
--- a/test/test_js_codegen.js
+++ b/test/test_js_codegen.js
@@ -2,6 +2,8 @@ const assert = require('assert')
 
 const {
   MISSING,
+  GROUPCOL,
+  JOINCOL,
   csv2TidyBlocksDataFrame,
   registerPrefix,
   registerSuffix,
@@ -11,6 +13,7 @@ const {
   assert_hasKey,
   assert_includes,
   assert_match,
+  assert_setEqual,
   assert_startsWith,
   loadBlockFiles,
   makeCode,

--- a/test/test_js_error.js
+++ b/test/test_js_error.js
@@ -2,6 +2,8 @@ const assert = require('assert')
 
 const {
   MISSING,
+  GROUPCOL,
+  JOINCOL,
   csv2TidyBlocksDataFrame,
   registerPrefix,
   registerSuffix,
@@ -11,6 +13,7 @@ const {
   assert_hasKey,
   assert_includes,
   assert_match,
+  assert_setEqual,
   assert_startsWith,
   loadBlockFiles,
   makeBlock,

--- a/test/test_js_utils.js
+++ b/test/test_js_utils.js
@@ -3,6 +3,8 @@ const Papa = require('papaparse')
 
 const {
   MISSING,
+  GROUPCOL,
+  JOINCOL,
   csv2TidyBlocksDataFrame,
   registerPrefix,
   registerSuffix,
@@ -12,6 +14,7 @@ const {
   assert_hasKey,
   assert_includes,
   assert_match,
+  assert_setEqual,
   assert_startsWith,
   loadBlockFiles,
   makeBlock,
@@ -201,9 +204,9 @@ describe('testing utilities run correctly', () => {
     const env = evalCode(pipeline)
     assert.equal(env.error, '',
                  `Expected no error when creating missing value`)
-    assert.equal(env.table.length, 1,
+    assert.equal(env.frame.data.length, 1,
                  `Expected one row of output`)
-    assert.equal(env.table[0].na, MISSING,
+    assert.equal(env.frame.data[0].na, MISSING,
                  `Expected missing value in new column`)
     done()
   })

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,6 +12,8 @@ const Papa = require('papaparse')
 module.paths.unshift(process.cwd())
 const {
   MISSING,
+  GROUPCOL,
+  JOINCOL,
   csv2TidyBlocksDataFrame,
   registerPrefix,
   registerSuffix,
@@ -87,6 +89,18 @@ const assert_match = (actual, required, message) => {
       actual: actual,
       expected: required})
   }
+}
+
+/**
+ * Assert that two sets are equal (used for checking columns).
+ * @param left One set.
+ * @param right The other set.
+ */
+const assert_setEqual = (left, right) => {
+  assert.equal(left.size, right.size,
+               `Expected same number of columns in sorted result`)
+  left.forEach(name => assert(right.has(name),
+                              `Expected ${name} in sorted results`))
 }
 
 /**
@@ -305,11 +319,11 @@ class TestEnvironment {
   }
 
   /**
-   * "Display" a table (record for testing purposes).
+   * "Display" a dataframe (record for testing purposes).
    * @param data {Object} - data to record.
    */
-  displayTable (data) {
-    this.table = data
+  displayFrame (frame) {
+    this.frame = frame
   }
 
   /**
@@ -370,6 +384,8 @@ const createTestingBlocks = () => {
 //
 module.exports = {
   MISSING,
+  GROUPCOL,
+  JOINCOL,
   csv2TidyBlocksDataFrame,
   registerPrefix,
   registerSuffix,
@@ -379,6 +395,7 @@ module.exports = {
   assert_hasKey,
   assert_includes,
   assert_match,
+  assert_setEqual,
   assert_startsWith,
   loadBlockFiles,
   makeBlock,

--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -74,11 +74,11 @@ class GuiEnvironment {
   }
 
   /**
-   * Display a table (as HTML).
+   * Display a dataframe as HTML.
    * @param {Object} table JSON array of uniform objects.
    */
-  displayTable (table) {
-    document.getElementById('dataOutput').innerHTML = json2table(table)
+  displayFrame (frame) {
+    document.getElementById('dataOutput').innerHTML = json2table(frame.data)
   }
 
   /**


### PR DESCRIPTION
This change stores column names in a set so that an empty dataframe still has columns to display.
An alternative would be to create a new `EmptyTidyBlocksDataFrame` class explicitly to have no data (but columns).

Closes #182.