### PR TITLE
Adding test for filtering by missing values.

### DIFF
--- a/blocks/value_blocks.js
+++ b/blocks/value_blocks.js
@@ -104,35 +104,3 @@ Blockly.defineBlocksWithJsonArray([
     tooltip: 'constant text'
   }
 ])
-
-//
-// Visuals for type checking block.
-//
-Blockly.defineBlocksWithJsonArray([
-  {
-    type: 'value_type',
-    message0: '%1 is %2 ?',
-    args0: [
-      {
-        type: 'input_value',
-        name: 'VALUE'
-      },
-      {
-        type: 'field_dropdown',
-        name: 'TYPE',
-        options: [
-          ['boolean', 'tbIsBoolean'],
-          ['date', 'tbIsDateTime'],
-          ['missing', 'tbIsMissing'],
-          ['number', 'tbIsNumber'],
-          ['string', 'tbIsString']
-        ]
-      }
-    ],
-    inputsInline: true,
-    output: 'Boolean',
-    style: 'value_blocks',
-    tooltip: 'check the type of a value',
-    helpUrl: ''
-  }
-])

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -1513,4 +1513,25 @@ describe('check that specific bugs have been fixed', () => {
     done()
   })
 
+  it('filters undefined values correct (#230)', (done) => {
+    for (let columnName of ['number', 'string', 'date']) {
+      const pipeline = [
+        {_b: 'data_missing'},
+        {_b: 'transform_filter',
+         TEST: {_b: 'operation_type',
+                TYPE: 'tbIsMissing',
+                VALUE: {_b: 'value_column',
+                        COLUMN: columnName}}}
+      ]
+      const env = evalCode(pipeline)
+      assert.equal(env.error, '',
+                   `Expected no error from pipeline`)
+      assert.equal(env.frame.data.length, 1,
+                   `Wrong number of columns in output ${env.frame.data.length}`)
+      assert.equal(env.frame.data[0][columnName], undefined,
+                   `Expected undefined value in ${columnName} not ${env.frame.data[0][columnName]}`)
+    }
+    done()
+  })
+
 })


### PR DESCRIPTION
1.  Added test case.
2.  Removed unused block definition (`value_type` doesn't exist - it's now `operation_type`).

Closes #230.