### PR TITLE
Displaying all columns after summarization.

### DIFF
--- a/blocks/transform_blocks.js
+++ b/blocks/transform_blocks.js
@@ -96,6 +96,9 @@ Blockly.defineBlocksWithJsonArray([
   }
 ])
 
+//
+// Visuals for sorting block.
+//
 Blockly.defineBlocksWithJsonArray([
 {
   type: "transform_sort",
@@ -160,3 +163,26 @@ Blockly.defineBlocksWithJsonArray([
   }
 ])
 
+//
+// Visuals for unique rows block.
+//
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'transform_unique',
+    message0: 'Unique %1',
+    args0: [
+      {
+        type: 'field_input',
+        name: 'MULTIPLE_COLUMNS',
+        text: 'column, column'
+      }
+    ],
+    inputsInline: true,
+    previousStatement: null,
+    nextStatement: null,
+    style: 'transform_blocks',
+    tooltip: 'select rows with unique values',
+    helpUrl: '',
+    extensions: ['validate_MULTIPLE_COLUMNS']
+  }
+])

--- a/generators/js/transform_blocks.js
+++ b/generators/js/transform_blocks.js
@@ -43,6 +43,9 @@ Blockly.JavaScript['transform_select'] = (block) => {
   return `.select(${block.tbId}, [${columns}])`
 }
 
+//
+// Sort data.
+//
 Blockly.JavaScript['transform_sort'] = (block) => {
   const columns = block.getFieldValue('MULTIPLE_COLUMNS')
         .split(',')
@@ -55,7 +58,7 @@ Blockly.JavaScript['transform_sort'] = (block) => {
 }
 
 //
-// Summarize data:
+// Summarize data.
 //
 Blockly.JavaScript['transform_summarize'] = (block) => {
   const branch = Blockly.JavaScript.statementToCode(block, "COLUMN_FUNC_PAIR")
@@ -68,4 +71,18 @@ Blockly.JavaScript['transform_summarize'] = (block) => {
 //
 Blockly.JavaScript['transform_ungroup'] = (block) => {
   return `.ungroup(${block.tbId})`
+}
+
+//
+// Select rows with unique values.
+//
+Blockly.JavaScript['transform_unique'] = (block) => {
+  const columns = block.getFieldValue('MULTIPLE_COLUMNS')
+        .split(',')
+        .map(c => c.trim())
+        .filter(c => (c.length > 0))
+        .map(c => Blockly.JavaScript.quote_(c))
+        .join(',')
+
+  return `.unique(${block.tbId}, [${columns}])`
 }

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
               </block>
               <block type="transform_summarize_item"></block>
               <block type="transform_ungroup"></block>
+              <block type="transform_unique"></block>
             </category>
             <category name="plot" categorystyle="plot">
               <block type="plot_bar"></block>

--- a/test/test_js_codegen.js
+++ b/test/test_js_codegen.js
@@ -221,6 +221,17 @@ describe('generate code for single blocks', () => {
     done()
   })
 
+  it('generates code to unique by one column', (done) => {
+    const pipeline = {_b: 'transform_unique',
+                      MULTIPLE_COLUMNS: 'someColumn'}
+    const code = makeCode(pipeline)
+    assert_startsWith(code, '.unique',
+                      'pipeline does not start with unique call')
+    assert_includes(code, 'someColumn',
+                    'pipeline does not include column name')
+    done()
+  })
+
   it('generates a bar plot', (done) => {
     const pipeline = {_b: 'plot_bar',
                       X_AXIS: {_b: 'value_column',

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -1186,12 +1186,14 @@ describe('check that grouping and summarization work', () => {
         ]}
     ]
     const env = evalCode(pipeline)
-    assert.equal(env.frame.data.length, 1,
+    assert.equal(env.error, '',
+                 `Expected no error from pipeline`)
+    assert.equal(env.frame.data.length, 11,
                  'Expected one row of output')
-    assert.equal(Object.keys(env.frame.data[0]).length, 1,
-                 'Expected a single column of output')
-    assert.equal(env.frame.data[0].red_sum, 1148,
-                 'Incorrect sum')
+    assert(env.frame.data.every(row => (row.red_sum === 1148)),
+           'Rows do not contain correct sum')
+    assert(!env.frame.hasColumns(GROUPCOL),
+           'Should not have grouping column with ungrouped summarize')
     done()
   })
 
@@ -1252,13 +1254,9 @@ describe('check that grouping and summarization work', () => {
        ]}
     ]
     const env = evalCode(pipeline)
-    const expected = [106.33333333333333, 127.5, 0].map((val, i) => {
-      const result = {green_mean: val}
-      result[GROUPCOL] = i
-      return result
-    })
-    assert.deepEqual(env.frame.data, expected,
-                     'Incorrect averaging')
+    const expected = [106.33333333333333, 127.5, 0]
+    assert(env.frame.data.every(row => (row.green_mean === expected[row[GROUPCOL]])),
+           'Incorrect mean green values')
     done()
   })
 
@@ -1273,10 +1271,10 @@ describe('check that grouping and summarization work', () => {
        ]}
     ]
     const env = evalCode(pipeline)
-    assert(env.frame.data.length == 1,
-           `Expect a single row of output`)
-    assert(env.frame.data[0].second_max == 200,
-           `Expected a max of 200, not ${env.frame.data[0].second}`)
+    assert(env.frame.data.length == 2,
+           `Expect two rows of output`)
+    assert(env.frame.data.every(row => (row.second_max === 200)),
+           `Expected a max of 200 for all rows`)
     done()
   })
 
@@ -1301,14 +1299,14 @@ describe('check that grouping and summarization work', () => {
     const env = evalCode(pipeline)
     assert.equal(env.error, '',
                  `Expected no error from pipeline`)
-    assert.equal(env.frame.data.length, 1,
-                 `Expect a single row of output`)
-    assert.equal(env.frame.data[0].value_min, 20,
-                 `Expected a mean of 20, not ${env.frame.data[0].value_min}`)
-    assert.equal(env.frame.data[0].value_mean, 32.5,
-                 `Expected a mean of 32.5, not ${env.frame.data[0].value_mean}`)
-    assert.equal(env.frame.data[0].value_max, 45,
-                 `Expected a max of 45, not ${env.frame.data[0].value_max}`)
+    assert.equal(env.frame.data.length, 6,
+                 `Expected 6 rows of output`)
+    assert(env.frame.data.every(row => (row.value_min === 20)),
+           `Expected a min of 20`)
+    assert(env.frame.data.every(row => (row.value_mean === 32.5)),
+           `Expected a mean of 32.5`)
+    assert(env.frame.data.every(row => (row.value_max === 45)),
+           `Expected a max of 45`)
     done()
   })
 
@@ -1378,10 +1376,10 @@ describe('check that grouping and summarization work', () => {
        ]}
     ]
     const env = evalCode(pipeline)
-    assert.equal(env.frame.data.length, 1,
-                 `Expect one row of output not ${env.frame.data.length}`)
-    assert.equal(env.frame.data[0].red_count, 11,
-                 `Expect a count of 11 rows, not ${env.frame.data[0].red_count}`)
+    assert.equal(env.frame.data.length, 11,
+                 `Expect 11 rows of output not ${env.frame.data.length}`)
+    assert(env.frame.data.every(row => (row.red_count === 11)),
+           `Expect a count of 11 rows`)
     done()
   })
 
@@ -1396,10 +1394,10 @@ describe('check that grouping and summarization work', () => {
        ]}
     ]
     const env = evalCode(pipeline)
-    assert.equal(env.frame.data.length, 1,
-                 `Expect one row of output not ${env.frame.data.length}`)
-    assert.equal(env.frame.data[0].red_median, 0,
-                 `Expect a median of 0, not ${env.frame.data[0].red_median}`)
+    assert.equal(env.frame.data.length, 11,
+                 `Expect 11 rows of output not ${env.frame.data.length}`)
+    assert(env.frame.data.every(row => (row.red_median === 0)),
+           `Expect a median of 0`)
     done()
   })
 
@@ -1417,14 +1415,16 @@ describe('check that grouping and summarization work', () => {
        ]}
     ]
     const env = evalCode(pipeline)
-    assert.equal(env.frame.data.length, 1,
+    assert.equal(env.frame.data.length, 11,
                  `Expect one row of output not ${env.frame.data.length}`)
     const expected_variance = 14243.140495867769
     const expected_std = 119.34462910356615
-    assert_approxEquals(env.frame.data[0].red_variance, expected_variance,
-                        `Expect a variance of ${expected_variance}, not ${env.frame.data[0].red_variance}`)
-    assert_approxEquals(env.frame.data[0].green_std, expected_std,
-                        `Expect a standard deviation of ${expected_std}, not ${env.frame.data[0].green_std}`)
+    env.frame.data.forEach(row => {
+      assert_approxEquals(row.red_variance, expected_variance,
+                          `Expect a variance of ${expected_variance}, not ${row.red_variance}`)
+      assert_approxEquals(row.green_std, expected_std,
+                          `Expect a standard deviation of ${expected_std}, not ${row.green_std}`)
+    })
     done()
   })
 

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -125,6 +125,60 @@ describe('execute blocks for entire pipelines', () => {
     done()
   })
 
+  it('selects unique rows when all are unique', (done) => {
+    const pipeline = [
+      {_b: 'data_double'},
+      {_b: 'transform_unique',
+       MULTIPLE_COLUMNS: 'first'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, '',
+                 `Expected no error from pipeline`)
+    assert.equal(env.frame.data.length, 2,
+                 `Expected 2 rows in result`)
+    done()
+  })
+
+  it('selects unique rows when there are duplicates', (done) => {
+    const pipeline = [
+      {_b: 'data_colors'},
+      {_b: 'transform_select',
+       MULTIPLE_COLUMNS: 'red'},
+      {_b: 'transform_unique',
+       MULTIPLE_COLUMNS: 'red'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, '',
+                 `Expected no error from pipeline`)
+    assert.equal(env.frame.data.length, 3,
+                 `Expected 3 rows in result, not ${env.frame.data.length}`)
+    const expectedValues = new Set([0, 128, 255])
+    const actualValues = new Set(env.frame.data.map(row => row.red))
+    assert_setEqual(actualValues, expectedValues,
+                    `Expected ${expectedValues} not ${actualValues}`)
+    done()
+  })
+
+  it('selects unique rows using two columns', (done) => {
+    const pipeline = [
+      {_b: 'data_colors'},
+      {_b: 'transform_select',
+       MULTIPLE_COLUMNS: 'red, green'},
+      {_b: 'transform_unique',
+       MULTIPLE_COLUMNS: 'red, green'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, '',
+                 `Expected no error from pipeline`)
+    assert.equal(env.frame.data.length, 6,
+                 `Expected 6 rows in result, not ${env.frame.data.length}`)
+    const expectedValues = new Set(['0:0', '0:128', '0:255', '128:0', '255:0', '255:255'])
+    const actualValues = new Set(env.frame.data.map(row => `${row.red}:${row.green}`))
+    assert_setEqual(actualValues, expectedValues,
+                    `Expected ${expectedValues} not ${actualValues}`)
+    done()
+  })
+
   it('converts numeric data to string', (done) => {
     const pipeline = [
       {_b: 'data_colors'},


### PR DESCRIPTION
1.  Change implementation of `summarize` to retain all columns.
2.  Update tests to reflect.

Closes #241.