### PR TITLE
add clear plot function and add to plot chaining

### DIFF
--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -196,6 +196,14 @@ const createValidator = (columnName, pattern) => {
 }
 
 /**
+ * @param {div} elementID of div to clear
+ */
+function clearBox(elementID)
+{
+    document.getElementById(elementID).innerHTML = "";
+}
+
+/**
  * Run the code generated from the user's blocks.
  * Depends on the global TidyBlocksWorkspace variable.
  */

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -1040,9 +1040,12 @@ class TidyBlocksDataFrame {
    * @param {object} environment Connection to the outside world.
    * @param {object} spec Vega-Lite specification with empty 'values' (filled in here with actual data before plotting).
    * @returns This object.
+   * 
+   * If the suffix does not contain a plot, it clears the plotArea
    */
   plot (environment, spec) {
     environment.displayFrame(this)
+    clearBox("plotOutput")
     if (Object.keys(spec).length !== 0) {
       spec.data.values = this.data
       environment.displayPlot(spec)
@@ -1309,6 +1312,7 @@ class TidyBlocksManagerClass {
         throw new Error('pipeline does not have a valid start block')
       }
       code = fixCode(code)
+      console.log(code)
       eval(code)
       while (this.queue.length > 0) {
         const func = this.queue.shift()


### PR DESCRIPTION
I created a clearBox function to be used within plot: 

```
 plot (environment, spec) {
    environment.displayFrame(this)
    clearBox("plotOutput")
    if (Object.keys(spec).length !== 0) {
      spec.data.values = this.data
      environment.displayPlot(spec)
    }
  }
```

but this creates a bunch of testing errors. Any ideas on how to exclude this function from the testing environment? 