### PR TITLE
Adding beside block

### DIFF
--- a/blocks/combine_blocks.js
+++ b/blocks/combine_blocks.js
@@ -1,9 +1,31 @@
 //
+// Visuals for notification block.
+//
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'combine_notify',
+    message0: 'Notify %1',
+    args0: [
+      {
+        type: 'field_input',
+        name: 'NAME',
+        text: 'name'
+      }
+    ],
+    previousStatement: null,
+    style: 'combine_blocks',
+    tooltip: 'notify a join that a table is available',
+    helpUrl: '',
+    extensions: ['validate_NAME']
+  }
+])
+
+//
 // Visuals for join block.
 //
 Blockly.defineBlocksWithJsonArray([
   {
-    type: 'plumbing_join',
+    type: 'combine_join',
     message0: 'Join %1 %2 %3 %4',
     args0: [
       {
@@ -29,32 +51,10 @@ Blockly.defineBlocksWithJsonArray([
     ],
     inputsInline: true,
     nextStatement: null,
-    style: 'plumbing_blocks',
+    style: 'combine_blocks',
     hat: 'cap',
-    tooltip: 'join two tables',
+    tooltip: 'join two tables by matching values',
     helpUrl: '',
     extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
-  }
-])
-
-//
-// Visuals for notification block.
-//
-Blockly.defineBlocksWithJsonArray([
-  {
-    type: 'plumbing_notify',
-    message0: 'Notify %1',
-    args0: [
-      {
-        type: 'field_input',
-        name: 'NAME',
-        text: 'name'
-      }
-    ],
-    previousStatement: null,
-    style: 'plumbing_blocks',
-    tooltip: 'notify a join that a table is available',
-    helpUrl: '',
-    extensions: ['validate_NAME']
   }
 ])

--- a/blocks/combine_blocks.js
+++ b/blocks/combine_blocks.js
@@ -58,3 +58,32 @@ Blockly.defineBlocksWithJsonArray([
     extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
   }
 ])
+
+//
+// Visuals for beside block.
+//
+Blockly.defineBlocksWithJsonArray([
+  {
+    type: 'combine_beside',
+    message0: 'Beside %1 %2',
+    args0: [
+      {
+        type: 'field_input',
+        name: 'LEFT_TABLE',
+        text: 'left_table'
+      },
+      {
+        type: 'field_input',
+        name: 'RIGHT_TABLE',
+        text: 'right_table'
+      }
+    ],
+    inputsInline: true,
+    nextStatement: null,
+    style: 'combine_blocks',
+    hat: 'cap',
+    tooltip: 'put two tables beside each other',
+    helpUrl: '',
+    extensions: ['validate_LEFT_TABLE', 'validate_RIGHT_TABLE']
+  }
+])

--- a/generators/js/combine_blocks.js
+++ b/generators/js/combine_blocks.js
@@ -1,5 +1,5 @@
 //
-// Create a notification block.
+// Generate code to notify pipeline completion.
 //
 Blockly.JavaScript['combine_notify'] = (block) => {
   const name = block.getFieldValue('NAME')
@@ -18,4 +18,15 @@ Blockly.JavaScript['combine_join'] = (block) => {
   const rightColumn = block.getFieldValue('RIGHT_COLUMN')
   const prefix = registerPrefix(`'${leftTable}', '${rightTable}'`)
   return `${prefix} new TidyBlocksDataFrame([]).join((name) => TidyBlocksManager.getResult(name), '${leftTable}', '${leftColumn}', '${rightTable}', '${rightColumn}')`
+}
+
+//
+// Generate code to put two datasets beside each other
+//
+Blockly.JavaScript['combine_beside'] = (block) => {
+  const order = Blockly.JavaScript.ORDER_NONE
+  const leftTable = block.getFieldValue('LEFT_TABLE')
+  const rightTable = block.getFieldValue('RIGHT_TABLE')
+  const prefix = registerPrefix(`'${leftTable}', '${rightTable}'`)
+  return `${prefix} new TidyBlocksDataFrame([]).beside((name) => TidyBlocksManager.getResult(name), '${leftTable}', '${rightTable}')`
 }

--- a/generators/js/combine_blocks.js
+++ b/generators/js/combine_blocks.js
@@ -1,8 +1,16 @@
+//
+// Create a notification block.
+//
+Blockly.JavaScript['combine_notify'] = (block) => {
+  const name = block.getFieldValue('NAME')
+  const suffix = registerSuffix(`'${name}'`)
+  return `.notify((name, frame) => TidyBlocksManager.notify(name, frame), '${name}') ${suffix}`
+}
 
 //
 // Generate code to join two datasets.
 //
-Blockly.JavaScript['plumbing_join'] = (block) => {
+Blockly.JavaScript['combine_join'] = (block) => {
   const order = Blockly.JavaScript.ORDER_NONE
   const leftTable = block.getFieldValue('LEFT_TABLE')
   const leftColumn = block.getFieldValue('LEFT_COLUMN')
@@ -10,13 +18,4 @@ Blockly.JavaScript['plumbing_join'] = (block) => {
   const rightColumn = block.getFieldValue('RIGHT_COLUMN')
   const prefix = registerPrefix(`'${leftTable}', '${rightTable}'`)
   return `${prefix} new TidyBlocksDataFrame([]).join((name) => TidyBlocksManager.getResult(name), '${leftTable}', '${leftColumn}', '${rightTable}', '${rightColumn}')`
-}
-
-//
-// Create a notification block.
-//
-Blockly.JavaScript['plumbing_notify'] = (block) => {
-  const name = block.getFieldValue('NAME')
-  const suffix = registerSuffix(`'${name}'`)
-  return `.notify((name, frame) => TidyBlocksManager.notify(name, frame), '${name}') ${suffix}`
 }

--- a/index.html
+++ b/index.html
@@ -94,9 +94,9 @@
               <block type="value_number"></block>
               <block type="value_text"></block>
             </category>
-            <category name="plumbing" categorystyle="plumbing">
-              <block type="plumbing_join"></block>
-              <block type="plumbing_notify"></block>
+            <category name="combine" categorystyle="combine">
+              <block type="combine_notify"></block>
+              <block type="combine_join"></block>
             </category>
           </xml>
         </div>
@@ -165,7 +165,7 @@
       <script src="blocks/data_blocks.js"></script>
       <script src="blocks/operation_blocks.js"></script>
       <script src="blocks/plot_blocks.js"></script>
-      <script src="blocks/plumbing_blocks.js"></script>
+      <script src="blocks/combine_blocks.js"></script>
       <script src="blocks/transform_blocks.js"></script>
       <script src="blocks/transform_summarize_item.js"></script>
       <script src="blocks/value_blocks.js"></script>
@@ -174,7 +174,7 @@
       <script src="generators/js/data_blocks.js"></script>
       <script src="generators/js/operation_blocks.js"></script>
       <script src="generators/js/plot_blocks.js"></script>
-      <script src="generators/js/plumbing_blocks.js"></script>
+      <script src="generators/js/combine_blocks.js"></script>
       <script src="generators/js/transform_blocks.js"></script>
       <script src="generators/js/transform_summarize_item.js"></script>
       <script src="generators/js/value_blocks.js"></script>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
             <category name="combine" categorystyle="combine">
               <block type="combine_notify"></block>
               <block type="combine_join"></block>
+              <block type="combine_beside"></block>
             </category>
           </xml>
         </div>

--- a/test/test_js_codegen.js
+++ b/test/test_js_codegen.js
@@ -315,7 +315,16 @@ describe('generate code for single blocks', () => {
     done()
   })
 
-  it('generates code to joins two pipelines', (done) => {
+  it('generates code to notify that a pipeline has completed', (done) => {
+    const pipeline = {_b: 'combine_notify',
+                      NAME: 'output_name'}
+    const code = makeCode(pipeline)
+    assert.equal(code, ".notify((name, frame) => TidyBlocksManager.notify(name, frame), 'output_name') }, ['output_name']) /* tidyblocks end */",
+                 'pipeine does not notify properly')
+    done()
+  })
+
+  it('generates code to join two pipelines', (done) => {
     const pipeline = {_b: 'combine_join',
                       LEFT_TABLE: 'left_table',
                       LEFT_COLUMN: {_b: 'value_column',
@@ -333,12 +342,17 @@ describe('generate code for single blocks', () => {
     done()
   })
 
-  it('generates code to notify that a pipeline has completed', (done) => {
-    const pipeline = {_b: 'combine_notify',
-                      NAME: 'output_name'}
+  it('generates code to put two tables beside one another', (done) => {
+    const pipeline = {_b: 'combine_beside',
+                      LEFT_TABLE: 'left_table',
+                      RIGHT_TABLE: 'right_table'}
     const code = makeCode(pipeline)
-    assert.equal(code, ".notify((name, frame) => TidyBlocksManager.notify(name, frame), 'output_name') }, ['output_name']) /* tidyblocks end */",
-                 'pipeine does not notify properly')
+    assert_includes(code, 'TidyBlocksManager.register',
+                    'pipeline is not registered')
+    assert_includes(code, "['left_table', 'right_table']",
+                    'pipeline does not register dependencies')
+    assert_includes(code, 'new TidyBlocksDataFrame',
+                    'pipeline does not create a new dataframe')
     done()
   })
 

--- a/test/test_js_codegen.js
+++ b/test/test_js_codegen.js
@@ -316,7 +316,7 @@ describe('generate code for single blocks', () => {
   })
 
   it('generates code to joins two pipelines', (done) => {
-    const pipeline = {_b: 'plumbing_join',
+    const pipeline = {_b: 'combine_join',
                       LEFT_TABLE: 'left_table',
                       LEFT_COLUMN: {_b: 'value_column',
                                     COLUMN: 'left_column'},
@@ -334,7 +334,7 @@ describe('generate code for single blocks', () => {
   })
 
   it('generates code to notify that a pipeline has completed', (done) => {
-    const pipeline = {_b: 'plumbing_notify',
+    const pipeline = {_b: 'combine_notify',
                       NAME: 'output_name'}
     const code = makeCode(pipeline)
     assert.equal(code, ".notify((name, frame) => TidyBlocksManager.notify(name, frame), 'output_name') }, ['output_name']) /* tidyblocks end */",

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -549,7 +549,7 @@ describe('check plotting', () => {
 
 })
 
-describe('check notify/join', () => {
+describe('check table combining', () => {
 
   beforeEach(() => {
     TidyBlocksManager.reset()
@@ -672,6 +672,64 @@ describe('check notify/join', () => {
     })
     assert.deepEqual(env.frame.data, expected,
                      'Incorrect join result')
+    done()
+  })
+
+  it('runs two pipelines and puts their results beside each other when the left is shorter', (done) => {
+    const pipeline = [
+      // Left data stream.
+      {_b: 'data_single'},
+      {_b: 'combine_notify',
+       NAME: 'left'},
+
+      // Right data stream.
+      {_b: 'data_double'},
+      {_b: 'combine_notify',
+       NAME: 'right'},
+
+      // Join.
+      {_b: 'combine_beside',
+       LEFT_TABLE: 'left',
+       RIGHT_TABLE: 'right'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, '',
+                 `Expected no error`)
+    const expected = [
+      {left_first: 1, right_first: 1, right_second: 100},
+      {left_first: undefined, right_first: 2, right_second: 200}
+    ]
+    assert.deepEqual(env.frame.data, expected,
+                     'Incorrect result of beside')
+    done()
+  })
+
+  it('runs two pipelines and puts their results beside each other when the right is shorter', (done) => {
+    const pipeline = [
+      // Left data stream.
+      {_b: 'data_double'},
+      {_b: 'combine_notify',
+       NAME: 'left'},
+
+      // Right data stream.
+      {_b: 'data_single'},
+      {_b: 'combine_notify',
+       NAME: 'right'},
+
+      // Join.
+      {_b: 'combine_beside',
+       LEFT_TABLE: 'left',
+       RIGHT_TABLE: 'right'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, '',
+                 `Expected no error`)
+    const expected = [
+      {left_first: 1, left_second: 100, right_first: 1},
+      {left_first: 2, left_second: 200, right_first: undefined}
+    ]
+    assert.deepEqual(env.frame.data, expected,
+                     'Incorrect result of beside')
     done()
   })
 

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -565,7 +565,7 @@ describe('check notify/join', () => {
                      COLUMN: 'red'},
               RIGHT: {_b: 'value_number',
                       VALUE: 0}}},
-      {_b: 'plumbing_notify',
+      {_b: 'combine_notify',
        NAME: 'left'}
     ]
     const env = evalCode(pipeline)
@@ -582,16 +582,16 @@ describe('check notify/join', () => {
     const pipeline = [
       // Left data stream.
       {_b: 'data_single'},
-      {_b: 'plumbing_notify',
+      {_b: 'combine_notify',
        NAME: 'left'},
 
       // Right data stream.
       {_b: 'data_double'},
-      {_b: 'plumbing_notify',
+      {_b: 'combine_notify',
        NAME: 'right'},
 
       // Join.
-      {_b: 'plumbing_join',
+      {_b: 'combine_join',
        LEFT_TABLE: 'left',
        LEFT_COLUMN: 'first',
        RIGHT_TABLE: 'right',
@@ -618,7 +618,7 @@ describe('check notify/join', () => {
                      COLUMN: 'red'},
               RIGHT: {_b: 'value_number',
                       VALUE: 0}}},
-      {_b: 'plumbing_notify',
+      {_b: 'combine_notify',
        NAME: 'left'},
 
       // Right data stream is colors with green != 0.
@@ -630,11 +630,11 @@ describe('check notify/join', () => {
                      COLUMN: 'green'},
               RIGHT: {_b: 'value_number',
                       VALUE: 0}}},
-      {_b: 'plumbing_notify',
+      {_b: 'combine_notify',
        NAME: 'right'},
 
       // Join, then keep entries with blue != 0.
-      {_b: 'plumbing_join',
+      {_b: 'combine_join',
        LEFT_TABLE: 'left',
        LEFT_COLUMN: 'red',
        RIGHT_TABLE: 'right',

--- a/tidyblocks/themes.js
+++ b/tidyblocks/themes.js
@@ -38,7 +38,7 @@ const tidyBlockStyles = {
     colourTertiary: '#760918'
   },
 
-  plumbing_blocks: {
+  combine_blocks: {
     colourPrimary: '#404040',
     colourSecondary: '#404040',
     colourTertiary: '#A0A0A0',
@@ -62,7 +62,7 @@ const tidyCategoryStyles = {
   value: {
     colour: '#E7553C'
   },
-  plumbing: {
+  combine: {
     colour: '#808080'
   }
 }


### PR DESCRIPTION
Adding a block to put two tables beside each other.
    
This is needed for running statistical tests that compare two datasets of possibly unequal length.
    
1.  Define block.
2.  Implement method in `tidyblocks.js`.
3.  Move `notify` to the top of `combine`.

Depends on #273.