### PR TITLE
Adding block to concatenate selected columns.

### DIFF
--- a/blocks/combine_blocks.js
+++ b/blocks/combine_blocks.js
@@ -60,12 +60,12 @@ Blockly.defineBlocksWithJsonArray([
 ])
 
 //
-// Visuals for beside block.
+// Visuals for concatenate block.
 //
 Blockly.defineBlocksWithJsonArray([
   {
-    type: 'combine_beside',
-    message0: 'Beside %1 %2',
+    type: 'combine_concatenate',
+    message0: 'Concatenate %1 %2 %3 %4',
     args0: [
       {
         type: 'field_input',
@@ -74,16 +74,26 @@ Blockly.defineBlocksWithJsonArray([
       },
       {
         type: 'field_input',
+        name: 'LEFT_COLUMN',
+        text: 'left_column'
+      },
+      {
+        type: 'field_input',
         name: 'RIGHT_TABLE',
         text: 'right_table'
+      },
+      {
+        type: 'field_input',
+        name: 'RIGHT_COLUMN',
+        text: 'right_column'
       }
     ],
     inputsInline: true,
     nextStatement: null,
     style: 'combine_blocks',
     hat: 'cap',
-    tooltip: 'put two tables beside each other',
+    tooltip: 'concatenate columns from two tables',
     helpUrl: '',
-    extensions: ['validate_LEFT_TABLE', 'validate_RIGHT_TABLE']
+    extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
   }
 ])

--- a/generators/js/combine_blocks.js
+++ b/generators/js/combine_blocks.js
@@ -21,12 +21,14 @@ Blockly.JavaScript['combine_join'] = (block) => {
 }
 
 //
-// Generate code to put two datasets beside each other
+// Generate code to concatenate columns from two datasets.
 //
-Blockly.JavaScript['combine_beside'] = (block) => {
+Blockly.JavaScript['combine_concatenate'] = (block) => {
   const order = Blockly.JavaScript.ORDER_NONE
   const leftTable = block.getFieldValue('LEFT_TABLE')
+  const leftColumn = block.getFieldValue('LEFT_COLUMN')
   const rightTable = block.getFieldValue('RIGHT_TABLE')
+  const rightColumn = block.getFieldValue('RIGHT_COLUMN')
   const prefix = registerPrefix(`'${leftTable}', '${rightTable}'`)
-  return `${prefix} new TidyBlocksDataFrame([]).beside((name) => TidyBlocksManager.getResult(name), '${leftTable}', '${rightTable}')`
+  return `${prefix} new TidyBlocksDataFrame([]).concatenate((name) => TidyBlocksManager.getResult(name), '${leftTable}', '${leftColumn}', '${rightTable}', '${rightColumn}')`
 }

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
             <category name="combine" categorystyle="combine">
               <block type="combine_notify"></block>
               <block type="combine_join"></block>
-              <block type="combine_beside"></block>
+              <block type="combine_concatenate"></block>
             </category>
           </xml>
         </div>

--- a/test/test_js_codegen.js
+++ b/test/test_js_codegen.js
@@ -344,10 +344,14 @@ describe('generate code for single blocks', () => {
     done()
   })
 
-  it('generates code to put two tables beside one another', (done) => {
-    const pipeline = {_b: 'combine_beside',
+  it('generates code to concatenate two columns', (done) => {
+    const pipeline = {_b: 'combine_concatenate',
                       LEFT_TABLE: 'left_table',
-                      RIGHT_TABLE: 'right_table'}
+                      LEFT_COLUMN: {_b: 'value_column',
+                                    COLUMN: 'left_column'},
+                      RIGHT_TABLE: 'right_table',
+                      RIGHT_COLUMN: {_b: 'value_column',
+                                     COLUMN: 'right_column'}}
     const code = makeCode(pipeline)
     assert_includes(code, 'TidyBlocksManager.register',
                     'pipeline is not registered')

--- a/test/test_js_error.js
+++ b/test/test_js_error.js
@@ -224,4 +224,79 @@ describe('raises errors at the right times', () => {
     done()
   })
 
+  it('will not concatenate nonexistent left column', (done) => {
+    const pipeline = [
+      // Left data stream.
+      {_b: 'data_single'},
+      {_b: 'combine_notify',
+       NAME: 'left'},
+
+      // Right data stream.
+      {_b: 'data_colors'},
+      {_b: 'combine_notify',
+       NAME: 'right'},
+
+      // Join.
+      {_b: 'combine_concatenate',
+       LEFT_TABLE: 'left',
+       LEFT_COLUMN: 'nonexistent',
+       RIGHT_TABLE: 'right',
+       RIGHT_COLUMN: 'name'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, 'left table does not have column nonexistent',
+                 `Did not get expected error report "${env.error}"`)
+    done()
+  })
+
+  it('will not concatenate nonexistent right column', (done) => {
+    const pipeline = [
+      // Left data stream.
+      {_b: 'data_single'},
+      {_b: 'combine_notify',
+       NAME: 'left'},
+
+      // Right data stream.
+      {_b: 'data_colors'},
+      {_b: 'combine_notify',
+       NAME: 'right'},
+
+      // Join.
+      {_b: 'combine_concatenate',
+       LEFT_TABLE: 'left',
+       LEFT_COLUMN: 'first',
+       RIGHT_TABLE: 'right',
+       RIGHT_COLUMN: 'nonexistent'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, 'right table does not have column nonexistent',
+                 `Did not get expected error report "${env.error}"`)
+    done()
+  })
+
+  it('will not concatenate columns of different types', (done) => {
+    const pipeline = [
+      // Left data stream.
+      {_b: 'data_single'},
+      {_b: 'combine_notify',
+       NAME: 'left'},
+
+      // Right data stream.
+      {_b: 'data_colors'},
+      {_b: 'combine_notify',
+       NAME: 'right'},
+
+      // Join.
+      {_b: 'combine_concatenate',
+       LEFT_TABLE: 'left',
+       LEFT_COLUMN: 'first',
+       RIGHT_TABLE: 'right',
+       RIGHT_COLUMN: 'name'}
+    ]
+    const env = evalCode(pipeline)
+    assert.equal(env.error, 'Values 1 and black have different types',
+                 `Did not get expected error report "${env.error}"`)
+    done()
+  })
+
 })

--- a/test/test_js_exec.js
+++ b/test/test_js_exec.js
@@ -678,7 +678,7 @@ describe('check table combining', () => {
     done()
   })
 
-  it('runs two pipelines and puts their results beside each other when the left is shorter', (done) => {
+  it('concatenates columns from two tables', (done) => {
     const pipeline = [
       // Left data stream.
       {_b: 'data_single'},
@@ -691,48 +691,20 @@ describe('check table combining', () => {
        NAME: 'right'},
 
       // Join.
-      {_b: 'combine_beside',
+      {_b: 'combine_concatenate',
        LEFT_TABLE: 'left',
-       RIGHT_TABLE: 'right'}
+       LEFT_COLUMN: 'first',
+       RIGHT_TABLE: 'right',
+       RIGHT_COLUMN: 'first'}
     ]
     const env = evalCode(pipeline)
     assert.equal(env.error, '',
                  `Expected no error`)
-    const expected = [
-      {left_first: 1, right_first: 1, right_second: 100},
-      {left_first: undefined, right_first: 2, right_second: 200}
-    ]
+    const expected = [{'table': 'left', 'value': 1},
+                      {'table': 'right', 'value': 1},
+                      {'table': 'right', 'value': 2}]
     assert.deepEqual(env.frame.data, expected,
-                     'Incorrect result of beside')
-    done()
-  })
-
-  it('runs two pipelines and puts their results beside each other when the right is shorter', (done) => {
-    const pipeline = [
-      // Left data stream.
-      {_b: 'data_double'},
-      {_b: 'combine_notify',
-       NAME: 'left'},
-
-      // Right data stream.
-      {_b: 'data_single'},
-      {_b: 'combine_notify',
-       NAME: 'right'},
-
-      // Join.
-      {_b: 'combine_beside',
-       LEFT_TABLE: 'left',
-       RIGHT_TABLE: 'right'}
-    ]
-    const env = evalCode(pipeline)
-    assert.equal(env.error, '',
-                 `Expected no error`)
-    const expected = [
-      {left_first: 1, left_second: 100, right_first: 1},
-      {left_first: 2, left_second: 200, right_first: undefined}
-    ]
-    assert.deepEqual(env.frame.data, expected,
-                     'Incorrect result of beside')
+                     'Incorrect concatenation result')
     done()
   })
 

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -1031,6 +1031,40 @@ class TidyBlocksDataFrame {
   }
 
   /**
+   * Concatenate selected columns from two tables.
+   * @param {function} getDataFxn How to look up data by name.
+   * @param {string} leftFrame Notification name of left table to join.
+   * @param {string} leftColumn Name of column from left table.
+   * @param {string} rightFrame Notification name of right table to join.
+   * @param {string} rightColumn Name of column from right table.
+   * @returns A new dataframe.
+   */
+  concatenate (getDataFxn, leftFrameName, leftColumn, rightFrameName, rightColumn) {
+
+    const leftFrame = getDataFxn(leftFrameName)
+    tbAssert(leftFrame.hasColumns(leftColumn),
+             `left table does not have column ${leftColumn}`)
+    const rightFrame = getDataFxn(rightFrameName)
+    tbAssert(rightFrame.hasColumns(rightColumn),
+             `right table does not have column ${rightColumn}`)
+    if ((leftFrame.data.length > 0) && (rightFrame.data.length > 0)) {
+      const leftValue = leftFrame.data[0][leftColumn]
+      const rightValue = rightFrame.data[0][rightColumn]
+      tbAssertTypeEqual(leftValue, rightValue)
+    }
+
+    const result = []
+    for (let row of leftFrame.data) {
+      result.push({table: leftFrameName, value: row[leftColumn]})
+    }
+    for (let row of rightFrame.data) {
+      result.push({table: rightFrameName, value: row[rightColumn]})
+    }
+    
+    return new TidyBlocksDataFrame(result)
+  }
+
+  /**
    * Put two tables beside each other, extending as needed with missing values.
    * @param {function} getDataFxn How to look up data by name.
    * @param {string} leftFrame Notification name of left table to join.


### PR DESCRIPTION
1.  Create new 'concatenate' block to concatenate column A of table Left with column B of table Right to produce two-column result (one column identifying source table, another with values).
2.  Removed the block that put two tables beside one another: for statistical tests, the concatenate block will be more useful.
3.  Added tests.