### PR TITLE
Encapsulating plots

### DIFF
--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -91,9 +91,9 @@ Blockly.defineBlocksWithJsonArray([
         text: 'column'
       },
       {
-        type: 'field_input',
+        type: 'field_number',
         name: 'BINS',
-        text: '10'
+        value: 10
       }
     ],
     inputsInline: true,

--- a/generators/plot.js
+++ b/generators/plot.js
@@ -5,25 +5,11 @@ Blockly.JavaScript['plot_bar'] = (block) => {
   const x_axis = block.getFieldValue('X_AXIS')
   const y_axis = block.getFieldValue('Y_AXIS')
   const spec = `{
-    "data": { "values": null }, // set to dataframe inside plotting function
-    "mark": "bar",
-    "encoding": {
-      "x": {
-        "field": "${x_axis}",
-        "type": "ordinal"
-      },
-      "y": {
-        "field": "${y_axis}",
-        "type": "quantitative"
-      },
-      "tooltip": {
-        "field": "${y_axis}",
-        "type": "quantitative"
-      }
-    }
+    x_axis: '${x_axis}',
+    y_axis: '${y_axis}'
   }`
   const suffix = TbManager.registerSuffix('')
-  return `.plot(${block.tbId}, environment, ${spec}) ${suffix}`
+  return `.plot(${block.tbId}, environment, tbPlotBar(${spec})) ${suffix}`
 }
 
 //
@@ -33,24 +19,11 @@ Blockly.JavaScript['plot_box'] = (block) => {
   const x_axis = block.getFieldValue('X_AXIS')
   const y_axis = block.getFieldValue('Y_AXIS')
   const spec = `{
-    "data": { "values": null }, // set to dataframe inside plotting function
-    "mark": {
-      "type": "boxplot",
-      "extent": 1.5
-    },
-    "encoding": {
-      "x": {
-        "field": "${x_axis}",
-        "type": "ordinal"
-      },
-      "y": {
-        "field": "${y_axis}",
-        "type": "quantitative",
-      }
-    }
+    x_axis: '${x_axis}',
+    y_axis: '${y_axis}'
   }`
   const suffix = TbManager.registerSuffix('')
-  return `.plot(${block.tbId}, environment, ${spec}) ${suffix}`
+  return `.plot(${block.tbId}, environment, tbPlotBox(${spec})) ${suffix}`
 }
 
 //
@@ -60,25 +33,11 @@ Blockly.JavaScript['plot_dot'] = (block) => {
   const x_axis = block.getFieldValue('X_AXIS')
   const y_axis = block.getFieldValue('Y_AXIS')
   const spec = `{
-    "data": { "values": null }, // set to dataframe inside plotting function
-    "mark": {
-    	"type": "circle",
-    	"opacity": 1
-    },
-    "transform": [{
-    "window": [{"op": "rank", "as": "id"}],
-    "groupby": ["${x_axis}"]
-  	}],
-    "encoding": {
-      "x": {
-        "field": "${x_axis}",
-        "type": "ordinal"
-      },
-      "y": {"field": "id", "type": "ordinal", "axis": null, "sort": "descending"}
-    }
+    x_axis: '${x_axis}',
+    y_axis: '${y_axis}'
   }`
   const suffix = TbManager.registerSuffix('')
-  return `.plot(${block.tbId}, environment, ${spec}) ${suffix}`
+  return `.plot(${block.tbId}, environment, tbPlotDot(${spec})) ${suffix}`
 }
 
 //
@@ -88,25 +47,11 @@ Blockly.JavaScript['plot_hist'] = (block) => {
   const column = block.getFieldValue('COLUMN')
   const bins = parseFloat(block.getFieldValue('BINS'))
   const spec = `{
-    "data": { "values": null }, // set to dataframe inside plotting function
-    "mark": "bar",
-    "encoding": {
-      "x": {
-        "bin": {
-          "maxbins": ${bins}
-        },
-        "field": "${column}",
-        "type": "quantitative"
-      },
-      "y": {
-        "aggregate": "count",
-        "type": 'quantitative'
-      },
-      "tooltip": null
-    }
+    column: '${column}',
+    bins: ${bins}
   }`
   const suffix = TbManager.registerSuffix('')
-  return `.plot(${block.tbId}, environment, ${spec}) ${suffix}`
+  return `.plot(${block.tbId}, environment, tbPlotHist(${spec})) ${suffix}`
 }
 
 //
@@ -117,23 +62,10 @@ Blockly.JavaScript['plot_point'] = (block) => {
   const y_axis = block.getFieldValue('Y_AXIS')
   const color = block.getFieldValue('COLOR')
   const spec = `{
-    "data": { "values": null }, // set to dataframe inside plotting function
-    "mark": "point",
-    "encoding": {
-      "x": {
-        "field": "${x_axis}",
-        "type": "quantitative"
-      },
-      "y": {
-        "field": "${y_axis}",
-        "type": "quantitative"
-      },
-      "color": {
-        "field": "${color}",
-        "type": "nominal"
-      }
-    }
+    x_axis: '${x_axis}',
+    y_axis: '${y_axis}',
+    color: '${color}'
   }`
   const suffix = TbManager.registerSuffix('')
-  return `.plot(${block.tbId}, environment, ${spec}) ${suffix}`
+  return `.plot(${block.tbId}, environment, tbPlotPoint(${spec})) ${suffix}`
 }

--- a/generators/plot.js
+++ b/generators/plot.js
@@ -1,6 +1,3 @@
-const PLOT_WIDTH = 500
-const PLOT_HEIGHT = 300
-
 //
 // Create a bar plot.
 //
@@ -8,8 +5,6 @@ Blockly.JavaScript['plot_bar'] = (block) => {
   const x_axis = block.getFieldValue('X_AXIS')
   const y_axis = block.getFieldValue('Y_AXIS')
   const spec = `{
-    "width": ${PLOT_WIDTH},
-    "height": ${PLOT_HEIGHT},
     "data": { "values": null }, // set to dataframe inside plotting function
     "mark": "bar",
     "encoding": {
@@ -38,7 +33,6 @@ Blockly.JavaScript['plot_box'] = (block) => {
   const x_axis = block.getFieldValue('X_AXIS')
   const y_axis = block.getFieldValue('Y_AXIS')
   const spec = `{
-    "width": ${PLOT_WIDTH},
     "data": { "values": null }, // set to dataframe inside plotting function
     "mark": {
       "type": "boxplot",
@@ -66,7 +60,6 @@ Blockly.JavaScript['plot_dot'] = (block) => {
   const x_axis = block.getFieldValue('X_AXIS')
   const y_axis = block.getFieldValue('Y_AXIS')
   const spec = `{
-    "height": 300,
     "data": { "values": null }, // set to dataframe inside plotting function
     "mark": {
     	"type": "circle",
@@ -95,8 +88,6 @@ Blockly.JavaScript['plot_hist'] = (block) => {
   const column = block.getFieldValue('COLUMN')
   const bins = block.getFieldValue('BINS')
   const spec = `{
-    "width": ${PLOT_WIDTH},
-    "height": ${PLOT_HEIGHT},
     "data": { "values": null }, // set to dataframe inside plotting function
     "mark": "bar",
     "encoding": {
@@ -126,7 +117,6 @@ Blockly.JavaScript['plot_point'] = (block) => {
   const y_axis = block.getFieldValue('Y_AXIS')
   const color = block.getFieldValue('COLOR')
   const spec = `{
-    "width": ${PLOT_WIDTH},
     "data": { "values": null }, // set to dataframe inside plotting function
     "mark": "point",
     "encoding": {

--- a/generators/plot.js
+++ b/generators/plot.js
@@ -86,7 +86,7 @@ Blockly.JavaScript['plot_dot'] = (block) => {
 //
 Blockly.JavaScript['plot_hist'] = (block) => {
   const column = block.getFieldValue('COLUMN')
-  const bins = block.getFieldValue('BINS')
+  const bins = parseFloat(block.getFieldValue('BINS'))
   const spec = `{
     "data": { "values": null }, // set to dataframe inside plotting function
     "mark": "bar",

--- a/test/test_plot.js
+++ b/test/test_plot.js
@@ -28,12 +28,12 @@ describe('generates code for plotting blocks', () => {
     const code = TbTestUtils.makeCode(pipeline)
     assert.includes(code, '.plot(',
                     'pipeline does not call .plot')
+    assert.includes(code, 'tbPlotBar',
+                    'pipeline does not use right plot converter')
     assert.includes(code, 'X_axis_column',
                     'pipeline does not reference X axis column')
     assert.includes(code, 'Y_axis_column',
                     'pipeline does not reference Y axis column')
-    assert.includes(code, '"mark": "bar"',
-                    'pipeline does not use a bar')
     done()
   })
 
@@ -46,12 +46,12 @@ describe('generates code for plotting blocks', () => {
     const code = TbTestUtils.makeCode(pipeline)
     assert.includes(code, '.plot(',
                     'pipeline does not call .plot')
+    assert.includes(code, 'tbPlotBox',
+                    'pipeline does not use right plot converter')
     assert.includes(code, 'X_axis_column',
                     'pipeline does not reference X axis column')
     assert.includes(code, 'Y_axis_column',
                     'pipeline does not reference Y axis column')
-    assert.includes(code, '"type": "boxplot"',
-                    'pipeline is not a box plot')
     done()
   })
 
@@ -60,12 +60,14 @@ describe('generates code for plotting blocks', () => {
                       COLUMN: 'existingColumn',
                       BINS: 20}
     const code = TbTestUtils.makeCode(pipeline)
-    assert.includes(code, '"maxbins":',
-                    'pipeline does not include maxbins')
-    assert.includes(code, '"field": "existingColumn"',
+    assert.includes(code, '.plot(',
+                    'pipeline does not call .plot')
+    assert.includes(code, 'tbPlotHist',
+                    'pipeline does not use right plot converter')
+    assert.includes(code, 'bins',
+                    'pipeline does not include bins')
+    assert.includes(code, 'existingColumn',
                     'pipeline does not reference existing column')
-    assert.includes(code, '"mark": "bar"',
-                    'pipeline does not use a bar')
     done()
   })
 
@@ -80,14 +82,14 @@ describe('generates code for plotting blocks', () => {
     const code = TbTestUtils.makeCode(pipeline)
     assert.includes(code, '.plot(',
                     'pipeline does not call .plot')
+    assert.includes(code, 'tbPlotPoint',
+                    'pipeline does not use right plot converter')
     assert.includes(code, 'X_axis_column',
                     'pipeline does not reference X axis column')
     assert.includes(code, 'Y_axis_column',
                     'pipeline does not reference Y axis column')
     assert.includes(code, 'COLOR_axis_column',
                     'pipeline does not reference color axis column')
-    assert.includes(code, '"mark": "point"',
-                    'pipeline does not set the mark to point')
     done()
   })
 })
@@ -106,6 +108,8 @@ describe('executes plotting blocks', () => {
        BINS: 20}
     ]
     const env = TbTestUtils.evalCode(pipeline)
+    assert.equal(env.error, '',
+                 'Expected no error')
     assert(Array.isArray(env.frame.data),
            'Result table is not an array')
     assert.equal(env.frame.data.length, 150,
@@ -149,10 +153,8 @@ describe('executes plotting blocks', () => {
               RIGHT: {_b: 'value_number',
                       VALUE: 5.0}}},
       {_b: 'plot_hist',
-       COLUMN: {_b: 'value_column',
-                COLUMN: 'Petal_Length'},
-       BINS: {_b: 'value_number',
-              VALUE: 20}}
+       COLUMN: 'Petal_Length',
+       BINS: 20}
     ]
     const env = TbTestUtils.evalCode(pipeline)
     assert.equal(Object.keys(env.frame.data[0]).length, 5,

--- a/test/test_plot.js
+++ b/test/test_plot.js
@@ -58,7 +58,7 @@ describe('generates code for plotting blocks', () => {
   it('generates a histogram', (done) => {
     const pipeline = {_b: 'plot_hist',
                       COLUMN: 'existingColumn',
-                      BINS: '20'}
+                      BINS: 20}
     const code = TbTestUtils.makeCode(pipeline)
     assert.includes(code, '"maxbins":',
                     'pipeline does not include maxbins')
@@ -103,7 +103,7 @@ describe('executes plotting blocks', () => {
       {_b: 'data_iris'},
       {_b: 'plot_hist',
        COLUMN: 'Petal_Length',
-       BINS: '20'}
+       BINS: 20}
     ]
     const env = TbTestUtils.evalCode(pipeline)
     assert(Array.isArray(env.frame.data),
@@ -126,7 +126,7 @@ describe('executes plotting blocks', () => {
        MULTIPLE_COLUMNS: 'Petal_Length'},
       {_b: 'plot_hist',
        COLUMN: 'Petal_Length',
-       BINS: '20'}
+       BINS: 20}
     ]
     const env = TbTestUtils.evalCode(pipeline)
     assert.equal(Object.keys(env.frame.data[0]).length, 1,

--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -32,6 +32,10 @@ const MULTIPLE_COLUMN_FIELDS = [
 // Location of standard datasets.
 STANDARD_DATASET_BASE_URL = 'https://raw.githubusercontent.com/tidyblocks/tidyblocks/master/data/'
 
+// Size of standard plotting area.
+const PLOT_WIDTH = 500
+const PLOT_HEIGHT = 300
+
 //--------------------------------------------------------------------------------
 
 /**
@@ -93,6 +97,8 @@ class GuiEnvironment {
    * @param {Object} spec Vega-Lite spec for plot with data filled in.
    */
   displayPlot (spec) {
+    spec.width = PLOT_WIDTH
+    spec.height = PLOT_HEIGHT
     vegaEmbed('#plotOutput', spec, {})
   }
 

--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -99,6 +99,7 @@ class GuiEnvironment {
   displayPlot (spec) {
     spec.width = PLOT_WIDTH
     spec.height = PLOT_HEIGHT
+    console.log('IN DISPLAYPLOT SPEC IS', spec)
     vegaEmbed('#plotOutput', spec, {})
   }
 

--- a/tidyblocks/tidyblocks.js
+++ b/tidyblocks/tidyblocks.js
@@ -318,7 +318,7 @@ class TbDataFrame {
    * does not return 'this' to support further chaining.
    * @param {number} blockId Serial number of the block that triggered the call (used for debugging).
    * @param {object} environment Connection to the outside world that has a `displayPlot` method.
-   * @param {object} spec Vega-Lite specification with empty 'values' (filled in here with actual data before plotting).
+   * @param {object} spec Vega-Lite specification with data empty (filled in here).
    */
   plot (blockId, environment, spec) {
     environment.displayFrame(this)
@@ -1516,6 +1516,144 @@ const tbNormal = (blockId, mean, stdDev) => {
 const tbExponential = (blockId, rate) => {
   tbAssert(rate > 0, `[block ${blockId}] rate ${rate} must be positive`)
   return TbManager.stdlib.random.base.exponential(rate)
+}
+
+//--------------------------------------------------------------------------------
+// Fill in plotting specs.
+//--------------------------------------------------------------------------------
+
+/**
+ * Generate full Vega-Lite spec for bar plot.
+ * @param {object} spec Plot-specific values.
+ * @returns Full Vega-Lite spec.
+ */
+const tbPlotBar = (spec) => {
+  return {
+    'data': { 'values': null },
+    'mark': 'bar',
+    'encoding': {
+      'x': {
+        'field': spec.x_axis,
+        'type': 'ordinal'
+      },
+      'y': {
+        'field': spec.y_axis,
+        'type': 'quantitative'
+      },
+      'tooltip': {
+        'field': spec.y_axis,
+        'type': 'quantitative'
+      }
+    }
+  }
+}
+
+/**
+ * Generate full Vega-Lite spec for box plot.
+ * @param {object} spec Plot-specific values.
+ * @returns Full Vega-Lite spec.
+ */
+const tbPlotBox = (spec) => {
+  return {
+    'data': { 'values': null },
+    'mark': {
+      'type': 'boxplot',
+      'extent': 1.5
+    },
+    'encoding': {
+      'x': {
+        'field': spec.x_axis,
+        'type': 'ordinal'
+      },
+      'y': {
+        'field': spec.y_axis,
+        'type': 'quantitative',
+      }
+    }
+  }
+}
+
+/**
+ * Generate full Vega-Lite spec for dot plot.
+ * @param {object} spec Plot-specific values.
+ * @returns Full Vega-Lite spec.
+ */
+const tbPlotDot = (spec) => {
+  return {
+    'data': { 'values': null },
+    'mark': {
+    	'type': 'circle',
+    	'opacity': 1
+    },
+    'transform': [{
+        'window': [{'op': 'rank', 'as': 'id'}],
+        'groupby': [spec.x_axis]
+    }],
+    'encoding': {
+      'x': {
+        'field': spec.x_axis,
+        'type': 'ordinal'
+      },
+      'y': {
+        'field': 'id',
+        'type': 'ordinal',
+        'axis': null,
+        'sort': 'descending'
+      }
+    }
+  }
+}
+
+/**
+ * Generate full Vega-Lite spec for histogram.
+ * @param {object} spec Plot-specific values.
+ * @returns Full Vega-Lite spec.
+ */
+const tbPlotHist = (spec) => {
+  return {
+    'data': { 'values': null },
+    'mark': 'bar',
+    'encoding': {
+      'x': {
+        'bin': {
+          'maxbins': spec.bins
+        },
+        'field': spec.column,
+        'type': 'quantitative'
+      },
+      'y': {
+        'aggregate': 'count',
+        'type': 'quantitative'
+      },
+      'tooltip': null
+    }
+  }
+}
+
+/**
+ * Generate full Vega-Lite spec for point plot.
+ * @param {object} spec Plot-specific values.
+ * @returns Full Vega-Lite spec.
+ */
+const tbPlotPoint = (spec) => {
+  return {
+    'data': { 'values': null },
+    'mark': 'point',
+    'encoding': {
+      'x': {
+        'field': spec.x_axis,
+        'type': 'quantitative'
+      },
+      'y': {
+        'field': spec.y_axis,
+        'type': 'quantitative'
+      },
+      'color': {
+        'field': spec.color,
+        'type': 'nominal'
+      }
+    }
+  }
 }
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
Moving Vega-Lite spec generation out of code generator and into plotting utilities.

Along the way:

1.  Moving plot height and plot width into GUI.
2.  Using number instead of string for number of bins in histogram.