### PR TITLE
Reorganizing t test

### DIFF
--- a/generators/stats.js
+++ b/generators/stats.js
@@ -52,33 +52,12 @@ Blockly.JavaScript['stats_t_test_one_sample'] = (block) => {
 // Create a paired two-sided t-test.
 //
 Blockly.JavaScript['stats_t_test_paired'] = (block) => {
-
   const order = Blockly.JavaScript.ORDER_NONE
   const left = block.getFieldValue('LEFT_COLUMN')
   const right = block.getFieldValue('RIGHT_COLUMN')
   const significance = block.getFieldValue('SIGNIFICANCE')
   const params = `{alpha: ${significance}}`
-  const suffix = TbManager.registerSuffix('')
-
-  const spec = `{
-    "title": "Sampling Distribution of x̄₁ - x̄₂",
-    "data": {"sequence": {"start": -5, "stop": 5, "step": 0.1, "as": "x"}},
-    "transform": [{"calculate": "densityNormal(datum.x, 0, 1)", "as": "y"}],
-    "encoding": {
-      "x": {"field": "x", "type": "quantitative"},
-      "y": {"field": "y", "type": "quantitative"}
-    },
-    "layer": [
-      {"mark": "line"},
-      {"transform": [{"filter": "datum.x <= -0.58 "}],"mark": "area"},
-      {"transform": [{"filter": "datum.x >= 0.58 "}], "mark": "area"}
-    ],
-    "width": 300,
-    "height": 150
-  }`
-
-  return `.test(${block.tbId}, environment, tbTTestPaired, ${params}, "${left}", "${right}")
-  .ttestPlot(${block.tbId}, environment, tbTTestPaired, ${params}, "${left}", "${right}") ${suffix}`
+  return `.test(${block.tbId}, environment, tbTTestPaired, ${params}, "${left}", "${right}")`
 }
 
 //

--- a/tidyblocks/gui.js
+++ b/tidyblocks/gui.js
@@ -32,9 +32,9 @@ const MULTIPLE_COLUMN_FIELDS = [
 // Location of standard datasets.
 STANDARD_DATASET_BASE_URL = 'https://raw.githubusercontent.com/tidyblocks/tidyblocks/master/data/'
 
-// Size of standard plotting area.
-const PLOT_WIDTH = 500
-const PLOT_HEIGHT = 300
+// Size of standard plotting areas.
+const FULL_PLOT_SIZE = {width: 500, height: 300}
+const STATS_PLOT_SIZE = {width: 300, height: 150}
 
 //--------------------------------------------------------------------------------
 
@@ -97,9 +97,8 @@ class GuiEnvironment {
    * @param {Object} spec Vega-Lite spec for plot with data filled in.
    */
   displayPlot (spec) {
-    spec.width = PLOT_WIDTH
-    spec.height = PLOT_HEIGHT
-    console.log('IN DISPLAYPLOT SPEC IS', spec)
+    spec.width = FULL_PLOT_SIZE.width
+    spec.height = FULL_PLOT_SIZE.height
     vegaEmbed('#plotOutput', spec, {})
   }
 
@@ -118,8 +117,12 @@ class GuiEnvironment {
    * @param {Object} spec2 VegaLite spec for second plot.
    */
   displayStatsPlot (spec1, spec2) {
-    vegaEmbed('#statsPlot1', spec1, {})
-    vegaEmbed('#statsPlot2', spec2, {})
+    for (let [spec, label] of [[spec1, '#statsPlot1'],
+                               [spec2, '#statsPlot2']]) {
+      spec.width = STATS_PLOT_SIZE.width
+      spec.height = STATS_PLOT_SIZE.height
+      vegaEmbed(label, spec, {})
+    }
   }
 
   /**


### PR DESCRIPTION
Reorganizing code for two-sided t-test with plot.
    
1.  Removing unused spec from two-sided t-test generator
2.  Folding stats plots into test
3.  Simplifying height and width of plots
    
Requires #289.