### PR TITLE
Serve index.html without using jekyll.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,11 @@
----
-# Loads production files separately using jekyll.
-layout: null
----
-
 <html>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>TidyBlocks</title>
-    {% if jekyll.environment == "production" %}
-      <link rel="stylesheet" href="./dist_production/css/base.min.css">
-      <script src="./dist_production/tidyblocks.js"></script>
-    {% else %}
       <link rel="stylesheet" href="./dist/css/base.min.css">
       <script src="./dist/tidyblocks.js"></script>
-    {% endif %}
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"/>
     <script>
       let ui = null


### PR DESCRIPTION
Github action is updated to (1) not copy our `.gitignore` to gh_pages branch, and (2) copy `/dist/` to the same directory so we can keep this file consistent.