### PR TITLE
run button size and toolbox color

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -119,9 +119,9 @@ const THEME = Blockly.Theme.defineTheme('tidyblocks', {
     value: {colour: VALUE_COLOR}
   },
   componentStyles: {
-    toolboxBackgroundColour: '#455a64',
-    toolboxForegroundColour: '#fff',
-    flyoutBackgroundColour: '#ced7db',
+    toolboxBackgroundColour: '#e9eff2',
+    toolboxForegroundColour: '#1C313A',
+    flyoutBackgroundColour: '#F9F9F9',
   }
 })
 

--- a/static/sass/base.scss
+++ b/static/sass/base.scss
@@ -36,7 +36,7 @@ html, body, #root {
   font-weight: 400;
 }
 
-$runDiameter: 110px;
+$runDiameter: 60px;
 .runBtn{
   z-index: 3;
   width: $runDiameter;


### PR DESCRIPTION
Changed the run button size to be a bit smaller and a light colored toolbox

<img width="671" alt="Screen Shot 2020-08-04 at 9 06 52 PM" src="https://user-images.githubusercontent.com/6053906/89370863-974bff00-d696-11ea-84e2-1db458766f27.png">
