### PR TITLE
Adding a configuration flag for right-to-left support.

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -9,7 +9,7 @@
     <script>
       let ui = null
       window.onload = () => {
-        TidyBlocksUI = tidyblocks.setup('en', 'root')
+        TidyBlocksUI = tidyblocks.setup('en', 'root', false)
       }
     </script>
   </head>

--- a/es/index.html
+++ b/es/index.html
@@ -9,7 +9,7 @@
     <script>
       let ui = null
       window.onload = () => {
-        TidyBlocksUI = tidyblocks.setup('es', 'root')
+        TidyBlocksUI = tidyblocks.setup('es', 'root', false)
       }
     </script>
   </head>

--- a/index.js
+++ b/index.js
@@ -18,12 +18,13 @@ class ReactInterface extends UserInterface {
    * Build user interface object.
    * @param {string} language What language to use for localizing blocks.
    * @param {string} rootId HTML ID of root element.
+   * @param {Boolean} rightToLeft Right-to-left rendering?
    */
-  constructor (language, rootId) {
+  constructor (language, rootId, rightToLeft) {
     super(language)
 
     // Create the Blockly settings.
-    const settings = this._createSettings()
+    const settings = this._createSettings(rightToLeft)
 
     // Create an environment so the React app can get the pre-loaded datasets.
     const env = new Env(this)
@@ -50,7 +51,7 @@ class ReactInterface extends UserInterface {
    * Create the JSON settings used to initialize the workspace.
    * @returns JSON settings object.
    */
-  _createSettings () {
+  _createSettings (rightToLeft) {
     return {
       theme: blocks.THEME,
       zoom: {
@@ -61,7 +62,8 @@ class ReactInterface extends UserInterface {
         minScale: 0.3,
         scaleSpeed: 1.2
       },
-      renderer: 'thrasos'
+      renderer: 'thrasos',
+      RTL: rightToLeft
     }
   }
 }
@@ -70,9 +72,10 @@ class ReactInterface extends UserInterface {
  * Initialize the interface.
  * @param {string} language What language to use for localizing blocks.
  * @param {string} rootId HTML ID of element that will contain workspace.
+ * @param {Boolean} rtl Right-to-left rendering? (default is 'false').
  */
-const setup = (language, rootId) => {
-  return new ReactInterface(language, rootId)
+const setup = (language, rootId, rtl = false) => {
+  return new ReactInterface(language, rootId, rtl)
 }
 
 module.exports = {


### PR DESCRIPTION
1. `setup` and the constructor for `ReactInterface` now take a `rightToLeft` argument that should be `false` for left-to-right languages and `true` for right-to-left languages.
2. `index.html` for various languages now has this flag.

See the `demos/rtl` example in the Blockly source for more.