### PR TITLE
Adding language lookup for toolbox category names

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -270,74 +270,103 @@ const createBlocks = (language = 'en') => {
   }
 }
 
+// ----------------------------------------------------------------------
+// Toolbox configuration.
+// ----------------------------------------------------------------------
+
+const MSG = {
+  combine: {
+    en: 'combine'
+  },
+  data: {
+    en: 'data'
+  },
+  op: {
+    en: 'op'
+  },
+  plot: {
+    en: 'plot'
+  },
+  stats: {
+    en: 'stats'
+  },
+  transform: {
+    en: 'transform'
+  },
+  value: {
+    en: 'value'
+  }
+}
+
 /**
- * Configuration of blocks. This is here instead of in the HTML page in order to
- * avoid confusing React (which otherwise complains about `xml` being an unknown
- * UI component).
+ * Create XML configuration for toolbox, internationalizing the category names.
+ * @param {string} language Waht language to use for the string lookup table.
  */
-const XML_CONFIG = `<xml id="toolbox" style="display: none">
-  <category name="data" categorystyle="data">
-    <block type="data_colors"></block>
-    <block type="data_earthquakes"></block>
-    <block type="data_penguins"></block>
-    <block type="data_phish"></block>
-    <block type="data_sequence"></block>
-    <block type="data_user"></block>
-  </category>
-  <category name="transform" categorystyle="transform">
-    <block type="transform_create"></block>
-    <block type="transform_drop"></block>
-    <block type="transform_filter"></block>
-    <block type="transform_groupBy"></block>
-    <block type="transform_report"></block>
-    <block type="transform_select"></block>
-    <block type="transform_sort"></block>
-    <block type="transform_summarize"></block>
-    <block type="transform_ungroup"></block>
-    <block type="transform_unique"></block>
-  </category>
-  <category name="plot" categorystyle="plot">
-    <block type="plot_bar"></block>
-    <block type="plot_box"></block>
-    <block type="plot_dot"></block>
-    <block type="plot_histogram"></block>
-    <block type="plot_scatter"></block>
-  </category>
-  <category name="stats" categorystyle="stats">
-    <block type="stats_ttest_one"></block>
-    <block type="stats_ttest_two"></block>
-  </category>
-  <category name="op" categorystyle="op">
-    <block type="op_arithmetic"></block>
-    <block type="op_negate"></block>
-    <block type="op_compare"></block>
-    <block type="op_logical"></block>
-    <block type="op_not"></block>
-    <block type="op_type"></block>
-    <block type="op_convert"></block>
-    <block type="op_datetime"></block>
-    <block type="op_conditional"></block>
-    <block type="op_abs"></block>
-  </category>
-  <category name="value" categorystyle="value">
-    <block type="value_column"></block>
-    <block type="value_datetime"></block>
-    <block type="value_logical"></block>
-    <block type="value_number"></block>
-    <block type="value_text"></block>
-    <block type="value_rownum"></block>
-    <block type="value_exponential"></block>
-    <block type="value_normal"></block>
-    <block type="value_uniform"></block>
-  </category>
-  <category name="combine" categorystyle="combine">
-    <block type="combine_glue"></block>
-    <block type="combine_join"></block>
-  </category>
-</xml>`
+const createXmlConfig = (language = 'en') => {
+  return `<xml id="toolbox" style="display: none">
+    <category name="${MSG.data[language]}" categorystyle="data">
+      <block type="data_colors"></block>
+      <block type="data_earthquakes"></block>
+      <block type="data_penguins"></block>
+      <block type="data_phish"></block>
+      <block type="data_sequence"></block>
+      <block type="data_user"></block>
+    </category>
+    <category name="${MSG.transform[language]}" categorystyle="transform">
+      <block type="transform_create"></block>
+      <block type="transform_drop"></block>
+      <block type="transform_filter"></block>
+      <block type="transform_groupBy"></block>
+      <block type="transform_report"></block>
+      <block type="transform_select"></block>
+      <block type="transform_sort"></block>
+      <block type="transform_summarize"></block>
+      <block type="transform_ungroup"></block>
+      <block type="transform_unique"></block>
+    </category>
+    <category name="${MSG.plot[language]}" categorystyle="plot">
+      <block type="plot_bar"></block>
+      <block type="plot_box"></block>
+      <block type="plot_dot"></block>
+      <block type="plot_histogram"></block>
+      <block type="plot_scatter"></block>
+    </category>
+    <category name="${MSG.stats[language]}" categorystyle="stats">
+      <block type="stats_ttest_one"></block>
+      <block type="stats_ttest_two"></block>
+    </category>
+    <category name="${MSG.op[language]}" categorystyle="op">
+      <block type="op_arithmetic"></block>
+      <block type="op_negate"></block>
+      <block type="op_compare"></block>
+      <block type="op_logical"></block>
+      <block type="op_not"></block>
+      <block type="op_type"></block>
+      <block type="op_convert"></block>
+      <block type="op_datetime"></block>
+      <block type="op_conditional"></block>
+      <block type="op_abs"></block>
+    </category>
+    <category name="${MSG.value[language]}" categorystyle="value">
+      <block type="value_column"></block>
+      <block type="value_datetime"></block>
+      <block type="value_logical"></block>
+      <block type="value_number"></block>
+      <block type="value_text"></block>
+      <block type="value_rownum"></block>
+      <block type="value_exponential"></block>
+      <block type="value_normal"></block>
+      <block type="value_uniform"></block>
+    </category>
+    <category name="${MSG.combine[language]}" categorystyle="combine">
+      <block type="combine_glue"></block>
+      <block type="combine_join"></block>
+    </category>
+  </xml>`
+}
 
 module.exports = {
   THEME,
-  XML_CONFIG,
+  createXmlConfig,
   createBlocks
 }

--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -2,6 +2,8 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
+const {Messages} = require('./helpers')
+
 const combine = require('./combine')
 const data = require('./data')
 const op = require('./op')
@@ -274,7 +276,7 @@ const createBlocks = (language = 'en') => {
 // Toolbox configuration.
 // ----------------------------------------------------------------------
 
-const MSG = {
+const MESSAGES = {
   combine: {
     en: 'combine'
   },
@@ -300,11 +302,12 @@ const MSG = {
 
 /**
  * Create XML configuration for toolbox, internationalizing the category names.
- * @param {string} language Waht language to use for the string lookup table.
+ * @param {string} language What language to use for the string lookup table.
  */
-const createXmlConfig = (language = 'en') => {
+const createXmlConfig = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   return `<xml id="toolbox" style="display: none">
-    <category name="${MSG.data[language]}" categorystyle="data">
+    <category name="${msg.get('data')}" categorystyle="data">
       <block type="data_colors"></block>
       <block type="data_earthquakes"></block>
       <block type="data_penguins"></block>
@@ -312,7 +315,7 @@ const createXmlConfig = (language = 'en') => {
       <block type="data_sequence"></block>
       <block type="data_user"></block>
     </category>
-    <category name="${MSG.transform[language]}" categorystyle="transform">
+    <category name="${msg.get('transform')}" categorystyle="transform">
       <block type="transform_create"></block>
       <block type="transform_drop"></block>
       <block type="transform_filter"></block>
@@ -324,18 +327,18 @@ const createXmlConfig = (language = 'en') => {
       <block type="transform_ungroup"></block>
       <block type="transform_unique"></block>
     </category>
-    <category name="${MSG.plot[language]}" categorystyle="plot">
+    <category name="${msg.get('plot')}" categorystyle="plot">
       <block type="plot_bar"></block>
       <block type="plot_box"></block>
       <block type="plot_dot"></block>
       <block type="plot_histogram"></block>
       <block type="plot_scatter"></block>
     </category>
-    <category name="${MSG.stats[language]}" categorystyle="stats">
+    <category name="${msg.get('stats')}" categorystyle="stats">
       <block type="stats_ttest_one"></block>
       <block type="stats_ttest_two"></block>
     </category>
-    <category name="${MSG.op[language]}" categorystyle="op">
+    <category name="${msg.get('op')}" categorystyle="op">
       <block type="op_arithmetic"></block>
       <block type="op_negate"></block>
       <block type="op_compare"></block>
@@ -347,7 +350,7 @@ const createXmlConfig = (language = 'en') => {
       <block type="op_conditional"></block>
       <block type="op_abs"></block>
     </category>
-    <category name="${MSG.value[language]}" categorystyle="value">
+    <category name="${msg.get('value')}" categorystyle="value">
       <block type="value_column"></block>
       <block type="value_datetime"></block>
       <block type="value_logical"></block>
@@ -358,7 +361,7 @@ const createXmlConfig = (language = 'en') => {
       <block type="value_normal"></block>
       <block type="value_uniform"></block>
     </category>
-    <category name="${MSG.combine[language]}" categorystyle="combine">
+    <category name="${msg.get('combine')}" categorystyle="combine">
       <block type="combine_glue"></block>
       <block type="combine_join"></block>
     </category>

--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -2,10 +2,12 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
+const {Messages} = require('./helpers')
+
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   glue: {
     message0: {
       en: 'Glue left %1 right %2 labels %3',
@@ -57,72 +59,73 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // Glue
     {
       type: 'combine_glue',
-      message0: MSG.glue.message0[language],
+      message0: msg.get('glue.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'LEFT_TABLE',
-          text: MSG.glue.table_name[language]
+          text: msg.get('glue.table_name')
         },
         {
           type: 'field_input',
           name: 'RIGHT_TABLE',
-          text: MSG.glue.table_name[language]
+          text: msg.get('glue.table_name')
         },
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: MSG.glue.label[language]
+          text: msg.get('glue.label')
         }
       ],
       inputsInline: false,
       nextStatement: null,
       style: 'combine_block',
       hat: 'cap',
-      tooltip: MSG.glue.tooltip[language],
+      tooltip: msg.get('glue.tooltip'),
       helpUrl: '',
       extensions: ['validate_LEFT_TABLE', 'validate_RIGHT_TABLE', 'validate_COLUMN']
     },
     // Join
     {
       type: 'combine_join',
-      message0: MSG.join.message0[language],
+      message0: msg.get('join.message0'),
       args0: [],
-      message1: MSG.join.message1[language],
+      message1: msg.get('join.message1'),
       args1: [
         {
           type: 'field_input',
           name: 'LEFT_TABLE',
-          text: MSG.join.table[language]
+          text: msg.get('join.table')
         },
         {
           type: 'field_input',
           name: 'LEFT_COLUMN',
-          text: MSG.join.column[language]
+          text: msg.get('join.column')
         }
       ],
-      message2: MSG.join.message2[language],
+      message2: msg.get('join.message2'),
       args2: [
         {
           type: 'field_input',
           name: 'RIGHT_TABLE',
-          text: MSG.join.table[language]
+          text: msg.get('join.table')
         },
         {
           type: 'field_input',
           name: 'RIGHT_COLUMN',
-          text: MSG.join.column[language]
+          text: msg.get('join.column')
         }
       ],
       inputsInline: false,
       nextStatement: null,
       style: 'combine_block',
       hat: 'cap',
-      tooltip: MSG.join.tooltip[language],
+      tooltip: msg.get('join.tooltip'),
       helpUrl: '',
       extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
     }

--- a/blocks/data.js
+++ b/blocks/data.js
@@ -2,10 +2,12 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
+const {Messages} = require('./helpers')
+
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   colors: {
     message0: {
       en: 'Colors',
@@ -81,52 +83,53 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // Colors
     {
       type: 'data_colors',
-      message0: MSG.colors.message0[language],
+      message0: msg.get('colors.message0'),
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: MSG.colors.tooltip[language]
+      tooltip: msg.get('colors.tooltip')
     },
     // Earthquakes
     {
       type: 'data_earthquakes',
-      message0: MSG.earthquakes.message0[language],
+      message0: msg.get('earthquakes.message0'),
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: MSG.earthquakes.tooltip[language]
+      tooltip: msg.get('earthquakes.tooltip')
     },
     // Penguins
     {
       type: 'data_penguins',
-      message0: MSG.penguins.message0[language],
+      message0: msg.get('penguins.message0'),
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: MSG.penguins.tooltip[language]
+      tooltip: msg.get('penguins.tooltip')
     },
     // Phish
     {
       type: 'data_phish',
-      message0: MSG.phish.message0[language],
+      message0: msg.get('phish.message0'),
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: MSG.phish.tooltip[language]
+      tooltip: msg.get('phish.tooltip')
     },
     // Sequence
     {
       type: 'data_sequence',
-      message0: MSG.sequence.message0[language],
+      message0: msg.get('sequence.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: MSG.sequence.args0_text[language]
+          text: msg.get('sequence.args0_text')
         },
         {
           type: 'field_number',
@@ -137,24 +140,24 @@ const setup = (language) => {
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: MSG.sequence.tooltip[language],
+      tooltip: msg.get('sequence.tooltip'),
       helpUrl: ''
     },
     // User data
     {
       type: 'data_user',
-      message0: MSG.data_user.message0[language],
+      message0: msg.get('data_user.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.data_user.args0_text[language]
+          text: msg.get('data_user.args0_text')
         }
       ],
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: MSG.data_user.tooltip[language],
+      tooltip: msg.get('data_user.tooltip'),
       helpUrl: ''
     }
   ])

--- a/blocks/helpers.js
+++ b/blocks/helpers.js
@@ -23,7 +23,45 @@ const valueToCode = (block, label) => {
   return raw
 }
 
+/**
+ * Create a table lookup object.
+ */
+class Messages {
+  /**
+   * Construct message lookup class.
+   * @param {object} messages Nested JSON lookup table.
+   * @param {string} language What language to use by preference.
+   * @param {string} defaultLanguage What to use if nothing else available (English).
+   */
+  constructor (messages, language, defaultLanguage = 'en') {
+    this.messages = messages
+    this.language = language
+    this.defaultLanguage = defaultLanguage
+  }
+
+  /**
+   * Look up a value in the preferred language if available, or the default
+   * language if not.
+   * @param {string} path Dot-separated path such as 'plot_bar.message0'.
+   * @returns String (or 'undefined' if not found).
+   */
+  get (path) {
+    const components = path.split('.')
+    const lookup = components.reduce((table, current) => {
+      return table[current]
+    }, this.messages)
+    if (this.language in lookup) {
+      return lookup[this.language]
+    }
+    if (this.defaultLanguage in lookup) {
+      return lookup[this.defaultLanguage]
+    }
+    return 'undefined'
+  }
+}
+
 module.exports = {
   ORDER_NONE,
-  valueToCode
+  valueToCode,
+  Messages
 }

--- a/blocks/op.js
+++ b/blocks/op.js
@@ -4,13 +4,14 @@ const Blockly = require('blockly/blockly_compressed')
 
 const {
   ORDER_NONE,
-  valueToCode
+  valueToCode,
+  Messages
 } = require('./helpers')
 
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   arithmetic: {
     tooltip: {
       en: 'do arithmetic',
@@ -98,6 +99,7 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // Binary arithmetic
     {
@@ -128,7 +130,7 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: MSG.arithmetic.tooltip[language],
+      tooltip: msg.get('arithmetic.tooltip'),
       helpUrl: ''
     },
 
@@ -145,7 +147,7 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: MSG.negate.tooltip[language],
+      tooltip: msg.get('negate.tooltip'),
       helpUrl: ''
     },
 
@@ -162,7 +164,7 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: MSG.abs.tooltip[language],
+      tooltip: msg.get('abs.tooltip'),
       helpUrl: ''
     },
 
@@ -195,7 +197,7 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: MSG.compare.tooltip[language],
+      tooltip: msg.get('compare.tooltip'),
       helpUrl: ''
     },
 
@@ -224,14 +226,14 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: MSG.logical.tooltip[language],
+      tooltip: msg.get('logical.tooltip'),
       helpUrl: ''
     },
 
     // Logical negation
     {
       type: 'op_not',
-      message0: MSG.not.message0[language],
+      message0: msg.get('not.message0'),
       args0: [
         {
           type: 'input_value',
@@ -241,14 +243,14 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: MSG.not.tooltip[language],
+      tooltip: msg.get('not.tooltip'),
       helpUrl: ''
     },
 
     // Type checking
     {
       type: 'op_type',
-      message0: MSG.type.message0[language],
+      message0: msg.get('type.message0'),
       args0: [
         {
           type: 'input_value',
@@ -269,14 +271,14 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: MSG.type.tooltip[language],
+      tooltip: msg.get('type.tooltip'),
       helpUrl: ''
     },
 
     // Type conversion
     {
       type: 'op_convert',
-      message0: MSG.convert.message0[language],
+      message0: msg.get('convert.message0'),
       args0: [
         {
           type: 'input_value',
@@ -296,14 +298,14 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: MSG.convert.tooltip[language],
+      tooltip: msg.get('convert.tooltip'),
       helpUrl: ''
     },
 
     // Datetime conversions
     {
       type: 'op_datetime',
-      message0: MSG.datetime.message0[language],
+      message0: msg.get('datetime.message0'),
       args0: [
         {
           type: 'field_dropdown',
@@ -326,14 +328,14 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: MSG.datetime.tooltip[language],
+      tooltip: msg.get('datetime.tooltip'),
       helpUrl: ''
     },
 
     // Conditional
     {
       type: 'op_conditional',
-      message0: MSG.conditional.message0[language],
+      message0: msg.get('conditional.message0'),
       args0: [
         {
           type: 'input_value',
@@ -351,7 +353,7 @@ const setup = (language) => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: MSG.conditional.tooltip[language],
+      tooltip: msg.get('conditional.tooltip'),
       helpUrl: ''
     }
   ])

--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -2,10 +2,12 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
+const {Messages} = require('./helpers')
+
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   name: {
     en: 'name',
     es: 'nombre'
@@ -79,33 +81,34 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // Bar plot
     {
       type: 'plot_bar',
-      message0: MSG.plot_bar.message0[language],
+      message0: msg.get('plot_bar.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.name[language]
+          text: msg.get('name')
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: MSG.x_axis[language]
+          text: msg.get('x_axis')
         },
         {
           type: 'field_input',
           name: 'Y_AXIS',
-          text: MSG.y_axis[language]
+          text: msg.get('y_axis')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: MSG.plot_bar.tooltip[language],
+      tooltip: msg.get('plot_bar.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS']
     },
@@ -113,29 +116,29 @@ const setup = (language) => {
     // Box plot
     {
       type: 'plot_box',
-      message0: MSG.plot_box.message0[language],
+      message0: msg.get('plot_box.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.name[language]
+          text: msg.get('name')
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: MSG.x_axis[language]
+          text: msg.get('x_axis')
         },
         {
           type: 'field_input',
           name: 'Y_AXIS',
-          text: MSG.y_axis[language]
+          text: msg.get('y_axis')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: MSG.plot_box.tooltip[language],
+      tooltip: msg.get('plot_box.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS']
     },
@@ -143,24 +146,24 @@ const setup = (language) => {
     // Dot plot
     {
       type: 'plot_dot',
-      message0: MSG.plot_dot.message0[language],
+      message0: msg.get('plot_dot.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.name[language]
+          text: msg.get('name')
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: MSG.x_axis[language]
+          text: msg.get('x_axis')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: MSG.plot_dot.tooltip[language],
+      tooltip: msg.get('plot_dot.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS']
     },
@@ -168,17 +171,17 @@ const setup = (language) => {
     // Histogram plot
     {
       type: 'plot_histogram',
-      message0: MSG.plot_histogram.message0[language],
+      message0: msg.get('plot_histogram.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.name[language]
+          text: msg.get('name')
         },
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: MSG.plot_histogram.column[language]
+          text: msg.get('plot_histogram.column')
         },
         {
           type: 'field_number',
@@ -190,7 +193,7 @@ const setup = (language) => {
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: MSG.plot_histogram.tooltip[language],
+      tooltip: msg.get('plot_histogram.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_COLUMN']
     },
@@ -198,22 +201,22 @@ const setup = (language) => {
     // Scatter plot
     {
       type: 'plot_scatter',
-      message0: MSG.plot_scatter.message0[language],
+      message0: msg.get('plot_scatter.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.name[language]
+          text: msg.get('name')
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: MSG.x_axis[language]
+          text: msg.get('x_axis')
         },
         {
           type: 'field_input',
           name: 'Y_AXIS',
-          text: MSG.y_axis[language]
+          text: msg.get('y_axis')
         },
         {
           type: 'field_input',
@@ -230,7 +233,7 @@ const setup = (language) => {
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: MSG.plot_scatter.tooltip[language],
+      tooltip: msg.get('plot_scatter.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS', 'validate_COLOR']
     }

--- a/blocks/stats.js
+++ b/blocks/stats.js
@@ -2,10 +2,12 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
+const {Messages} = require('./helpers')
+
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   stats_ttest_one: {
     message0: {
       en: 'One-sample t-test', 
@@ -61,23 +63,24 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // One-sample two-sided t-test
     {
       type: 'stats_ttest_one',
-      message0: MSG.stats_ttest_one.message0[language],
+      message0: msg.get('stats_ttest_one.message0'),
       args0: [],
-      message1: MSG.stats_ttest_one.message1[language],
+      message1: msg.get('stats_ttest_one.message1'),
       args1: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.stats_ttest_one.args1_name[language]
+          text: msg.get('stats_ttest_one.args1_name')
         },
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: MSG.stats_ttest_one.args1_column[language]
+          text: msg.get('stats_ttest_one.args1_column')
         },
         {
           type: 'field_number',
@@ -89,38 +92,38 @@ const setup = (language) => {
       previousStatement: null,
       nextStatement: null,
       style: 'stats_blocks',
-      tooltip: MSG.stats_ttest_one.tooltip[language],
+      tooltip: msg.get('stats_ttest_one.tooltip'),
       helpUrl: ''
     },
 
     // Two-sample two-sided t-test
     {
       type: 'stats_ttest_two',
-      message0: MSG.stats_ttest_two.message0[language],
+      message0: msg.get('stats_ttest_two.message0'),
       args0: [],
-      message1: MSG.stats_ttest_two.message1[language],
+      message1: msg.get('stats_ttest_two.message1'),
       args1: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.stats_ttest_two.args1_name[language]
+          text: msg.get('stats_ttest_two.args1_name')
         },
         {
           type: 'field_input',
           name: 'LABEL_COLUMN',
-          text: MSG.stats_ttest_two.args1_label[language]
+          text: msg.get('stats_ttest_two.args1_label')
         },
         {
           type: 'field_input',
           name: 'VALUE_COLUMN',
-          text: MSG.stats_ttest_two.args1_column[language]
+          text: msg.get('stats_ttest_two.args1_column')
         }
       ],
       inputsInline: false,
       previousStatement: null,
       nextStatement: null,
       style: 'stats_blocks',
-      tooltip: MSG.stats_ttest_two.tooltip[language],
+      tooltip: msg.get('stats_ttest_two.tooltip'),
       helpUrl: ''
     }
   ])

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -2,7 +2,10 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
-const {valueToCode} = require('./helpers')
+const {
+  valueToCode,
+  Messages
+} = require('./helpers')
 
 /**
  * Helper function to turn a string containing comma-separated column names into
@@ -21,7 +24,7 @@ const _formatMultiColNames = (raw) => {
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   multiple_columns: {
     en: 'column, column', 
     es: 'columna, columna'
@@ -149,16 +152,17 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // Create
     {
       type: 'transform_create',
-      message0: MSG.create.message0[language],
+      message0: msg.get('create.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: MSG.create.args0_text[language]
+          text: msg.get('create.args0_text')
         },
         {
           type: 'input_value',
@@ -169,7 +173,7 @@ const setup = (language) => {
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.create.tooltip[language],
+      tooltip: msg.get('create.tooltip'),
       helpUrl: '',
       extensions: ['validate_COLUMN']
     },
@@ -177,19 +181,19 @@ const setup = (language) => {
     // Drop
     {
       type: 'transform_drop',
-      message0: MSG.drop.message0[language],
+      message0: msg.get('drop.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: MSG.multiple_columns[language]
+          text: msg.get('multiple_columns')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.drop.args0_tooltip[language],
+      tooltip: msg.get('drop.args0_tooltip'),
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
@@ -197,37 +201,37 @@ const setup = (language) => {
     // Filter
     {
       type: 'transform_filter',
-      message0: MSG.filter.message0[language],
+      message0: msg.get('filter.message0'),
       args0: [
         {
           type: 'input_value',
-          name: MSG.filter.args0_name[language]
+          name: msg.get('filter.args0_name')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.filter.tooltip[language],
+      tooltip: msg.get('filter.tooltip'),
       helpUrl: ''
     },
 
     // Group
     {
       type: 'transform_groupBy',
-      message0: MSG.groupby.message0[language],
+      message0: msg.get('groupby.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: MSG.multiple_columns[language]
+          text: msg.get('multiple_columns')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.groupby.tooltip[language],
+      tooltip: msg.get('groupby.tooltip'),
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
@@ -235,18 +239,18 @@ const setup = (language) => {
     // Report
     {
       type: 'transform_report',
-      message0: MSG.report.message0[language],
+      message0: msg.get('report.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: MSG.report.args0_text[language]
+          text: msg.get('report.args0_text')
         }
       ],
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.report.tooltip[language],
+      tooltip: msg.get('report.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME']
     },
@@ -254,19 +258,19 @@ const setup = (language) => {
     // Select
     {
       type: 'transform_select',
-      message0: MSG.select.message0[language],
+      message0: msg.get('select.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: MSG.multiple_columns[language]
+          text: msg.get('multiple_columns')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.select.tooltip[language],
+      tooltip: msg.get('select.tooltip'),
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
@@ -274,12 +278,12 @@ const setup = (language) => {
     // Sort
     {
       type: 'transform_sort',
-      message0: MSG.sort.message0[language],
+      message0: msg.get('sort.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: MSG.multiple_columns[language]
+          text: msg.get('multiple_columns')
         },
         {
           type: 'field_checkbox',
@@ -292,14 +296,14 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       extensions: ['validate_MULTIPLE_COLUMNS'],
-      tooltip: MSG.sort.tooltip[language],
+      tooltip: msg.get('sort.tooltip'),
       helpUrl: ''
     },
 
     // Summarize
     {
       type: 'transform_summarize',
-      message0: MSG.summarize.message0[language],
+      message0: msg.get('summarize.message0'),
       args0: [
         {
           type: 'field_dropdown',
@@ -320,14 +324,14 @@ const setup = (language) => {
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: MSG.summarize.args0_text[language]
+          text: msg.get('summarize.args0_text')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.summarize.tooltip[language],
+      tooltip: msg.get('summarize.tooltip'),
       helpUrl: '',
       extensions: ['validate_COLUMN']
     },
@@ -335,32 +339,32 @@ const setup = (language) => {
     // Ungroup
     {
       type: 'transform_ungroup',
-      message0: MSG.ungroup.message0[language],
+      message0: msg.get('ungroup.message0'),
       args0: [],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.ungroup.tooltip[language],
+      tooltip: msg.get('ungroup.tooltip'),
       helpUrl: ''
     },
 
     // Unique
     {
       type: 'transform_unique',
-      message0: MSG.unique.message0[language],
+      message0: msg.get('unique.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: MSG.multiple_columns[language]
+          text: msg.get('multiple_columns')
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: MSG.unique.tooltip,
+      tooltip: msg.get('unique.tooltip'),
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     }

--- a/blocks/value.js
+++ b/blocks/value.js
@@ -2,12 +2,15 @@
 
 const Blockly = require('blockly/blockly_compressed')
 
-const {ORDER_NONE} = require('./helpers')
+const {
+  ORDER_NONE,
+  Messages
+} = require('./helpers')
 
 /**
  * Lookup table for message strings.
  */
-const MSG = {
+const MESSAGES = {
   absent: {
     message0: {
       en: 'Absent', 
@@ -107,16 +110,17 @@ const MSG = {
  * @param {string} language Two-letter language code to use for string lookups.
  */
 const setup = (language) => {
+  const msg = new Messages(MESSAGES, language, 'en')
   Blockly.defineBlocksWithJsonArray([
     // Absent value
     {
       type: 'value_absent',
-      message0: MSG.absent.message0[language],
+      message0: msg.get('absent.message0'),
       args0: [],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.absent.tooltip[language]
+      tooltip: msg.get('absent.tooltip')
     },
 
     // Column name
@@ -126,12 +130,12 @@ const setup = (language) => {
       args0: [{
         type: 'field_input',
         name: 'COLUMN',
-        text: MSG.column.column[language]
+        text: msg.get('column.column')
       }],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.column.tooltip[language],
+      tooltip: msg.get('column.tooltip'),
       extensions: ['validate_COLUMN']
     },
 
@@ -142,12 +146,12 @@ const setup = (language) => {
       args0: [{
         type: 'field_input',
         name: 'DATE',
-        text: MSG.datetime.text[language]
+        text: msg.get('datetime.text')
       }],
       output: 'DateTime',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.datetime.tooltip[language],
+      tooltip: msg.get('datetime.tooltip'),
       extensions: ['validate_DATE']
     },
 
@@ -168,7 +172,7 @@ const setup = (language) => {
       output: 'Boolean',
       helpUrl: '',
       style: 'value_block',
-      tooltip: MSG.logical.tooltip[language]
+      tooltip: msg.get('logical.tooltip')
     },
 
     // Number
@@ -183,7 +187,7 @@ const setup = (language) => {
       output: 'Number',
       helpUrl: '',
       style: 'value_block',
-      tooltip: MSG.number.tooltip[language]
+      tooltip: msg.get('number.tooltip')
     },
 
     // Text
@@ -194,30 +198,30 @@ const setup = (language) => {
         {
           type: 'field_input',
           name: 'VALUE',
-          text: MSG.text.text[language]
+          text: msg.get('text.text')
         }
       ],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.text.tooltip[language]
+      tooltip: msg.get('text.tooltip')
     },
 
     // Row number
     {
       type: 'value_rownum',
-      message0: MSG.rownum.message0[language],
+      message0: msg.get('rownum.message0'),
       args0: [],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.rownum.tooltip[language]
+      tooltip: msg.get('rownum.tooltip')
     },
 
     // Exponential random variable
     {
       type: 'value_exponential',
-      message0: MSG.exponential.message0[language],
+      message0: msg.get('exponential.message0'),
       args0: [
         {
           type: 'field_input',
@@ -228,14 +232,14 @@ const setup = (language) => {
       output: 'Number',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.exponential.tooltip[language],
+      tooltip: msg.get('exponential.tooltip'),
       extensions: ['validate_RATE']
     },
 
     // Normal random variable
     {
       type: 'value_normal',
-      message0: MSG.normal.message0[language],
+      message0: msg.get('normal.message0'),
       args0: [
         {
           type: 'field_input',
@@ -251,14 +255,14 @@ const setup = (language) => {
       output: 'Number',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.normal.tooltip[language],
+      tooltip: msg.get('normal.tooltip'),
       extensions: ['validate_STDDEV']
     },
 
     // Uniform random variable
     {
       type: 'value_uniform',
-      message0: MSG.uniform.message0[language],
+      message0: msg.get('uniform.message0'),
       args0: [
         {
           type: 'field_input',
@@ -274,7 +278,7 @@ const setup = (language) => {
       output: 'Number',
       style: 'value_block',
       helpUrl: '',
-      tooltip: MSG.uniform.tooltip[language]
+      tooltip: msg.get('uniform.tooltip')
     }
   ])
 

--- a/index.js
+++ b/index.js
@@ -28,9 +28,12 @@ class ReactInterface extends UserInterface {
     // Create an environment so the React app can get the pre-loaded datasets.
     const env = new Env(this)
 
+    // Create the XML configuration (internationalized).
+    const xmlConfig = blocks.createXmlConfig(language)
+
     // Render React.
     const app = ReactDOM.render(
-      <TidyBlocksApp settings={settings} toolbox={blocks.XML_CONFIG} initialEnv={env}/>,
+      <TidyBlocksApp settings={settings} toolbox={xmlConfig} initialEnv={env}/>,
       document.getElementById(rootId)
     )
 


### PR DESCRIPTION
1. Add a `Messages` class to `blocks/helpers.js` to look up translation messages for a particular language with a fallback if the language isn't found.
2. Use this class in all blocks.
3. Use this class in the XML toolbox description so that category names can be in various languages.

To do: test the `Messages` class. Feedback before then would be very welcome.