### PR TITLE
Update plot.js

### DIFF
--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -9,45 +9,55 @@ const MSG = {
   glue: {
     message0: {
       en: 'Glue left %1 right %2 labels %3',
-      es: 'Pegar izquierda %1 derecha %2 etiquetas %3'
+      es: 'Pegar izquierda %1 derecha %2 etiquetas %3',
+      ar: ''
     },
     table_name: {
       en: 'name',
-      es: 'nombre'
+      es: 'nombre',
+      ar: ''
     },
     label: {
       en: 'label',
-      es: 'etiqueta'
+      es: 'etiqueta',
+      ar: ''
     },
     tooltip: {
       en: 'glue rows from two tables together',
-      es: 'pegar juntas filas de dos tablas'
+      es: 'pegar juntas filas de dos tablas',
+      ar: ''
     }
   },
   join: {
     message0: {
       en: 'Join',
-      es: 'Unir'
+      es: 'Unir',
+      ar: ''
     },
     message1: {
       en: 'left %1 %2',
-      es: 'izquierda  %1 %2'
+      es: 'izquierda  %1 %2',
+      ar: ''
     },
     message2: {
       en: 'right %1 %2',
-      es: 'derecha %1 %2'
+      es: 'derecha %1 %2',
+      ar: ''
     },
     table: {
       en: 'table',
-      es: 'tabla'
+      es: 'tabla',
+      ar: ''
     },
     column: {
       en: 'column',
-      es: 'columna'
+      es: 'columna',
+      ar: ''
     },
     tooltip: {
       en: 'join two tables by matching values',
-      es: 'unir dos tables emparenjando valores'
+      es: 'unir dos tables emparenjando valores',
+      ar: ''
     }
   }
 }

--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -10,54 +10,54 @@ const MSG = {
     message0: {
       en: 'Glue left %1 right %2 labels %3',
       es: 'Pegar izquierda %1 derecha %2 etiquetas %3',
-      ar: ''
+      ar: 'دمج من جهة اليسار %1 اليمين %2 الفئات %3'
     },
     table_name: {
       en: 'name',
       es: 'nombre',
-      ar: ''
+      ar: 'الإسم'
     },
     label: {
       en: 'label',
       es: 'etiqueta',
-      ar: ''
+      ar: 'الفئة'
     },
     tooltip: {
       en: 'glue rows from two tables together',
       es: 'pegar juntas filas de dos tablas',
-      ar: ''
+      ar: 'دمج صفوف من جدولين'
     }
   },
   join: {
     message0: {
       en: 'Join',
       es: 'Unir',
-      ar: ''
+      ar: 'دمج'
     },
     message1: {
       en: 'left %1 %2',
       es: 'izquierda  %1 %2',
-      ar: ''
+      ar: 'يسار %1 %2'
     },
     message2: {
       en: 'right %1 %2',
       es: 'derecha %1 %2',
-      ar: ''
+      ar: 'يمين %1 %2'
     },
     table: {
       en: 'table',
       es: 'tabla',
-      ar: ''
+      ar: 'الجدول'
     },
     column: {
       en: 'column',
       es: 'columna',
-      ar: ''
+      ar: 'العمود'
     },
     tooltip: {
       en: 'join two tables by matching values',
       es: 'unir dos tables emparenjando valores',
-      ar: ''
+      ar: 'دمج جدولين عن طريق تشابه القيم'
     }
   }
 }

--- a/blocks/data.js
+++ b/blocks/data.js
@@ -10,82 +10,82 @@ const MSG = {
     message0: {
       en: 'Colors',
       es: 'Colores',
-      ar: ''
+      ar: 'الألوان'
     },
     tooltip: {
       en: 'eleven colors',
       es: 'once colores',
-      ar: ''
+      ar: 'احد عشر لون'
     }
   },
   earthquakes: {
     message0: {
       en: 'Earthquakes',
       es: 'Terremotos',
-      ar: ''
+      ar: 'الزلزال'
     },
     tooltip: {
       en: 'earthquake data', 
       es: 'datos de terremotos',
-      ar: ''
+      ar: 'بيانات الزلزال'
     }
   },
   penguins: {
     message0: {
       en: 'Penguins', 
       es: 'Pingüinos',
-      ar: ''
+      ar: 'طيور البطريق'
     },
     tooltip: {
       en: 'penguin data',
       es: 'datos de pingüinos',
-      ar: ''
+      ar: 'بيانات طيور البطريق'
     }
   },
   phish: {
     message0: {
       en: 'Phish', 
       es: 'Phish',
-      ar: ''
+      ar: 'فرقه الفيش الموسيقيه'
     },
     tooltip: {
       en: 'Phish concert data',
       es: 'datos de conciertos Phish',
-      ar: ''
+      ar: 'بيانات فرقه الفيش الموسيقيه'
     }
   },
   sequence: {
     message0: {
       en: 'Sequence %1 %2',
       es: 'Sequencia %1 %2',
-      ar: ''
+      ar: 'المتسلسله %1 %2'
     },
     args0_text: {
       en: 'name', 
       es: 'nombre',
-      ar: ''
+      ar: 'اﻹسم'
     },
     tooltip: {
       en: 'Generate a sequence 1..N',
       es: 'Generar una sequencia 1..N',
-      ar: ''
+      ar: 'إنشاء متسلسله ١..ن'
     }
   },
   data_user: {
     message0: {
       en: 'User data %1', 
       es: 'Datos de usuario %1',
-      ar: ''
+      ar: 'بيانات المسته %1'
     },
     args0_text: {
       en: 'name',
       es: 'nombre',
-      ar: ''
+      ar: 'الإسم'
     },
     tooltip: {
       en: 'use previously-loaded data', 
       es: 'usa datos previamente cargados',
-      ar: ''
+      ar: 'إستخدام بيانات محمله مسبقا'
     }
   }
 }

--- a/blocks/data.js
+++ b/blocks/data.js
@@ -9,69 +9,83 @@ const MSG = {
   colors: {
     message0: {
       en: 'Colors',
-      es: 'Colores'
+      es: 'Colores',
+      ar: ''
     },
     tooltip: {
       en: 'eleven colors',
-      es: 'once colores'
+      es: 'once colores',
+      ar: ''
     }
   },
   earthquakes: {
     message0: {
       en: 'Earthquakes',
-      es: 'Terremotos'
+      es: 'Terremotos',
+      ar: ''
     },
     tooltip: {
       en: 'earthquake data', 
-      es: 'datos de terremotos'
+      es: 'datos de terremotos',
+      ar: ''
     }
   },
   penguins: {
     message0: {
       en: 'Penguins', 
-      es: 'Pingüinos'
+      es: 'Pingüinos',
+      ar: ''
     },
     tooltip: {
       en: 'penguin data',
-      es: 'datos de pingüinos'
+      es: 'datos de pingüinos',
+      ar: ''
     }
   },
   phish: {
     message0: {
       en: 'Phish', 
-      es: 'Phish'
+      es: 'Phish',
+      ar: ''
     },
     tooltip: {
       en: 'Phish concert data',
-      es: 'datos de conciertos Phish'
+      es: 'datos de conciertos Phish',
+      ar: ''
     }
   },
   sequence: {
     message0: {
       en: 'Sequence %1 %2',
-      es: 'Sequencia %1 %2'
+      es: 'Sequencia %1 %2',
+      ar: ''
     },
     args0_text: {
       en: 'name', 
-      es: 'nombre'
+      es: 'nombre',
+      ar: ''
     },
     tooltip: {
       en: 'Generate a sequence 1..N',
-      es: 'Generar una sequencia 1..N'
+      es: 'Generar una sequencia 1..N',
+      ar: ''
     }
   },
   data_user: {
     message0: {
       en: 'User data %1', 
-      es: 'Datos de usuario %1'
+      es: 'Datos de usuario %1',
+      ar: ''
     },
     args0_text: {
       en: 'name',
-      es: 'nombre'
+      es: 'nombre',
+      ar: ''
     },
     tooltip: {
       en: 'use previously-loaded data', 
-      es: 'usa datos previamente cargados'
+      es: 'usa datos previamente cargados',
+      ar: ''
     }
   }
 }

--- a/blocks/op.js
+++ b/blocks/op.js
@@ -14,81 +14,96 @@ const MSG = {
   arithmetic: {
     tooltip: {
       en: 'do arithmetic',
-      es: 'haz la aritmética'
+      es: 'haz la aritmética',
+      ar: ''
     }
   },
   negate: {
     tooltip: {
       en: 'negate a numeric column',
-      es: 'excluye una columna numerica'
+      es: 'excluye una columna numerica',
+      ar: ''
     }
   },
   abs: {
     tooltip: {
       en: 'absolute value of a numeric column',
-      es: 'FIXME'
+      es: 'FIXME',
+      ar: ''
     }
   },
   compare: {
     tooltip: {
       en: 'compare two columns',
-      es: 'compara dos columnas'
+      es: 'compara dos columnas',
+      ar: ''
     }
   },
   logical: {
     tooltip: {
       en: 'combine logical values of two columns',
-      es: 'combina los valores logicos de dos columnas'
+      es: 'combina los valores logicos de dos columnas',
+      ar: ''
     }
   },
   not: {
     message0: {
       en: 'not %1',
-      es: 'no %1'
+      es: 'no %1',
+      ar: ''
     },
     tooltip: {
       en: 'negate a logical column',
-      es: 'excluye una columna numerica'
+      es: 'excluye una columna numerica',
+      ar: ''
     }
   },
   type: {
     message0: {
       en: '%1 is %2 ?',
-      es: '¿Es %1 %2 ?'
+      es: '¿Es %1 %2 ?',
+      ar: ''
     },
     tooltip: {
       en: 'check the type of a value',
-      es: 'comprueba el tipo de valor'
+      es: 'comprueba el tipo de valor',
+      ar: ''
     }
   },
   convert: {
     message0: {
       en: '%1 to %2',
-      es: '%1 a %2'
+      es: '%1 a %2',
+      ar: ''
     },
     tooltip: {
       en: 'change the datatype of a value',
-      es: 'cambia el tipo de dato del valor'
+      es: 'cambia el tipo de dato del valor',
+      ar: ''
     }
   },
   datetime: {
     message0: {
       en: 'get %1 from %2',
-      es: 'obten %1 de %2'
+      es: 'obten %1 de %2',
+      ar: ''
     },
     tooltip: {
       en: 'change the datatype of a value',
-      es: 'cambia el tipo de dato del valor'
+      es: 'cambia el tipo de dato del valor',
+      ar: ''
     }
   },
   conditional: {
     message0: {
       en: 'If %1 then %2 else %3',
-      es: 'Si %1 entonces %2 sino %3'
+      es: 'Si %1 entonces %2 sino %3',
+      ar: ''
     },
     tooltip: {
       en: 'select value based on condition',
-      es: 'selecciona el valor basandote en la condicion'
+      es: 'selecciona el valor basandote en la condicion',
+      ar: ''
     }
   }
 }

--- a/blocks/op.js
+++ b/blocks/op.js
@@ -15,95 +15,95 @@ const MSG = {
     tooltip: {
       en: 'do arithmetic',
       es: 'haz la aritmética',
-      ar: ''
+      ar: 'إجراء عمليات حسابيه'
     }
   },
   negate: {
     tooltip: {
       en: 'negate a numeric column',
       es: 'excluye una columna numerica',
-      ar: ''
+      ar: 'الغاء عمود حسابي'
     }
   },
   abs: {
     tooltip: {
       en: 'absolute value of a numeric column',
       es: 'FIXME',
-      ar: ''
+      ar: 'القيمه المطلقه لعمود حسابي'
     }
   },
   compare: {
     tooltip: {
       en: 'compare two columns',
       es: 'compara dos columnas',
-      ar: ''
+      ar: 'مقارنه عمودين'
     }
   },
   logical: {
     tooltip: {
       en: 'combine logical values of two columns',
       es: 'combina los valores logicos de dos columnas',
-      ar: ''
+      ar: 'دمج القيم المنطقيه لعمودين'
     }
   },
   not: {
     message0: {
       en: 'not %1',
       es: 'no %1',
-      ar: ''
+      ar: 'غير %1'
     },
     tooltip: {
       en: 'negate a logical column',
       es: 'excluye una columna numerica',
-      ar: ''
+      ar: 'إلغاء عمود منطقي'
     }
   },
   type: {
     message0: {
       en: '%1 is %2 ?',
       es: '¿Es %1 %2 ?',
-      ar: ''
+      ar: 'هل %1 هو %2؟'
     },
     tooltip: {
       en: 'check the type of a value',
       es: 'comprueba el tipo de valor',
-      ar: ''
+      ar: 'التعرف على نوع القيمه'
     }
   },
   convert: {
     message0: {
       en: '%1 to %2',
       es: '%1 a %2',
-      ar: ''
+      ar: 'من %1 إلي %2'
     },
     tooltip: {
       en: 'change the datatype of a value',
       es: 'cambia el tipo de dato del valor',
-      ar: ''
+      ar: 'تغيير نوع القيمه'
     }
   },
   datetime: {
     message0: {
       en: 'get %1 from %2',
       es: 'obten %1 de %2',
-      ar: ''
+      ar: 'الحصول على %1 من %2'
     },
     tooltip: {
       en: 'change the datatype of a value',
       es: 'cambia el tipo de dato del valor',
-      ar: ''
+      ar: 'تغيير نوع القيمه'
     }
   },
   conditional: {
     message0: {
       en: 'If %1 then %2 else %3',
       es: 'Si %1 entonces %2 sino %3',
-      ar: ''
+      ar: 'إذا %1 افعل %2 غير ذلك %3'
     },
     tooltip: {
       en: 'select value based on condition',
       es: 'selecciona el valor basandote en la condicion',
-      ar: ''
+      ar: 'اختيار قيمه توافي شرط'
     }
   }
 }

--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -8,68 +8,82 @@ const Blockly = require('blockly/blockly_compressed')
 const MSG = {
   name: {
     en: 'name',
-    es: 'nombre'
+    es: 'nombre',
+    ar: 'ﻹسم'
   },
   x_axis: {
     en: 'X axis',
-    es: 'eje X'
+    es: 'eje X',
+    ar: 'المحور الأفقي'
   },
   y_axis: {
     en: 'Y axis',
-    es: 'eje Y'
+    es: 'eje Y',
+    ar: 'المحور الرأسي'    
   },
   plot_bar: {
     message0: {
       en: 'Bar %1 %2 %3',
-      es: 'Barras %1 %2 %3'
+      es: 'Barras %1 %2 %3',
+      ar: 'الأعمده ١٪ ٢٪ ٣٪'
     },
     tooltip: {
       en: 'create bar plot',
-      es: 'crear grafico barras'
+      es: 'crear grafico barras',
+      ar: 'إنشاء رسم الأعمده البيانيه'
     }
   },
   plot_box: {
     message0: {
       en: 'Box %1 %2 %3',
-      es: 'Cajas %1 %2 %3'
+      es: 'Cajas %1 %2 %3',
+      ar: 'الصندوق ١٪ ٢٪ ٣٪'
     },
     tooltip: {
       en: 'create box plot',
-      es: 'crear grafico cajas'
+      es: 'crear grafico cajas',
+      ar: 'إنشاء مخطط الصندوق ذو العارضتين'
     }
   },
   plot_dot: {
     message0: {
       en: 'Dot %1 %2',
-      es: 'Puntos %1 %2'
+      es: 'Puntos %1 %2',
+      ar: 'النقطه ١٪ ٢٪'
     },
     tooltip: {
       en: 'create dot plot',
-      es: 'crear grafico puntos'
+      es: 'crear grafico puntos',
+      ar: 'إنشاء المخطط النقطي'
     }
   },
   plot_histogram: {
     message0: {
       en: 'Histogram %1 %2 %3',
-      es: 'Histograma %1 %2 %3'
+      es: 'Histograma %1 %2 %3',
+      ar: 'المدرج التكراري'
     },
     column: {
       en: 'column',
-      es: 'columna'
+      es: 'columna',
+      ar: '١٪ ٢٪'
     },
     tooltip: {
       en: 'create histogram',
-      es: 'crear histograma'
+      es: 'crear histograma',
+      ar: 'إنشاء المدرج التكراري'
     }
   },
   plot_scatter: {
     message0: {
       en: 'Scatter %1 %2 %3 Color %4 Add Line? %5',
-      es: 'Dispersion %1 %2 %3 Color %4 Añadir linea? %5'
+      es: 'Dispersion %1 %2 %3 Color %4 Añadir linea? %5',
+      ar: 'التشتت ١٪ ٢٪ ٣٪ اللون ٤٪ إضافه خط؟٥٪'
     },
     tooltip: {
       en: 'create scatter plot',
-      en: 'crear grafico dispersion'
+      en: 'crear grafico dispersion',
+      ar: 'إنشاء مخطط الإنتشار'
     }
   }
 }

--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -9,7 +9,7 @@ const MSG = {
   name: {
     en: 'name',
     es: 'nombre',
-    ar: 'ﻹسم'
+    ar: 'الإسم'
   },
   x_axis: {
     en: 'X axis',
@@ -25,7 +25,7 @@ const MSG = {
     message0: {
       en: 'Bar %1 %2 %3',
       es: 'Barras %1 %2 %3',
-      ar: 'الأعمده ١٪ ٢٪ ٣٪'
+      ar: 'الأعمده %1 %2 %3'
     },
     tooltip: {
       en: 'create bar plot',
@@ -37,7 +37,7 @@ const MSG = {
     message0: {
       en: 'Box %1 %2 %3',
       es: 'Cajas %1 %2 %3',
-      ar: 'الصندوق ١٪ ٢٪ ٣٪'
+      ar: 'الصندوق %1 %2 %3'
     },
     tooltip: {
       en: 'create box plot',
@@ -49,7 +49,7 @@ const MSG = {
     message0: {
       en: 'Dot %1 %2',
       es: 'Puntos %1 %2',
-      ar: 'النقطه ١٪ ٢٪'
+      ar: 'النقطه %1 %2'
     },
     tooltip: {
       en: 'create dot plot',
@@ -61,12 +61,12 @@ const MSG = {
     message0: {
       en: 'Histogram %1 %2 %3',
       es: 'Histograma %1 %2 %3',
-      ar: 'المدرج التكراري'
+      ar: 'المدرج التكراري %1 %2 %3'
     },
     column: {
       en: 'column',
       es: 'columna',
-      ar: '١٪ ٢٪'
+      ar: 'العمود'
     },
     tooltip: {
       en: 'create histogram',
@@ -78,7 +78,7 @@ const MSG = {
     message0: {
       en: 'Scatter %1 %2 %3 Color %4 Add Line? %5',
       es: 'Dispersion %1 %2 %3 Color %4 Añadir linea? %5',
-      ar: 'التشتت ١٪ ٢٪ ٣٪ اللون ٤٪ إضافه خط؟٥٪'
+      ar: 'التشتت %1 %2 %3 اللون %4 إضافه خط؟ %5'
     },
     tooltip: {
       en: 'create scatter plot',

--- a/blocks/stats.js
+++ b/blocks/stats.js
@@ -9,49 +9,60 @@ const MSG = {
   stats_ttest_one: {
     message0: {
       en: 'One-sample t-test', 
-      es: 'T-test para una muestra'
+      es: 'T-test para una muestra',
+      ar: ''
     },
     message1: {
       en: 'name %1 column %2 mean \u03BC %3',
-      es: 'nombre %1 columna %2 media \u03BC %3'
+      es: 'nombre %1 columna %2 media \u03BC %3',
+      ar: ''
     },
     args1_name: {
       en: 'name',
-      es: 'nombre'
+      es: 'nombre',
+      ar: ''
     },
     args1_column: {
       en: 'column',
-      es: 'columna'
+      es: 'columna',
+      ar: ''
     },
     tooltip: {
       en: 'perform one-sample two-sided t-test',
-      es: 'hacer t-test para una muestra dos colas'
+      es: 'hacer t-test para una muestra dos colas',
+      ar: ''
     }
   },
   stats_ttest_two: {
     message0: {
       en: 'Two-sample t-test',
-      es: 'T-test para dos muestras'
+      es: 'T-test para dos muestras',
+      ar: ''
     },
     message1: {
       en: 'name %1 labels %2 values %3',
-      es: 'nombre %1 etiquetas %2 valores %3'
+      es: 'nombre %1 etiquetas %2 valores %3',
+      ar: ''
     },
     args1_name: {
       en: 'name',
-      es: 'nombre'
+      es: 'nombre',
+      ar: ''
     },
     args1_label: {
       en: 'label',
-      es: 'etiqueta'
+      es: 'etiqueta',
+      ar: ''
     },
     args1_column: {
       en: 'column',
-      es: 'columna'
+      es: 'columna',
+      ar: ''
     },
     tooltip: {
       en: 'perform two-sample two-sided t-test',
-      es: 'hacer t-test para dos muestras dos colas'
+      es: 'hacer t-test para dos muestras dos colas',
+      ar: ''
     }
   }
 }

--- a/blocks/stats.js
+++ b/blocks/stats.js
@@ -10,59 +10,59 @@ const MSG = {
     message0: {
       en: 'One-sample t-test', 
       es: 'T-test para una muestra',
-      ar: ''
+      ar: 'إختبار (ت) لعينه واحده'
     },
     message1: {
       en: 'name %1 column %2 mean \u03BC %3',
       es: 'nombre %1 columna %2 media \u03BC %3',
-      ar: ''
+      ar: 'الإسم %1 العمود %2 الوسط الحسابي \u03BC %3'
     },
     args1_name: {
       en: 'name',
       es: 'nombre',
-      ar: ''
+      ar: 'الإسم'
     },
     args1_column: {
       en: 'column',
       es: 'columna',
-      ar: ''
+      ar: 'العمود'
     },
     tooltip: {
       en: 'perform one-sample two-sided t-test',
       es: 'hacer t-test para una muestra dos colas',
-      ar: ''
+      ar: 'إختبار (ت) ذو الاتجاهين لعينه واحده'
     }
   },
   stats_ttest_two: {
     message0: {
       en: 'Two-sample t-test',
       es: 'T-test para dos muestras',
-      ar: ''
+      ar: 'إختبار (ت) لعينتين'
     },
     message1: {
       en: 'name %1 labels %2 values %3',
       es: 'nombre %1 etiquetas %2 valores %3',
-      ar: ''
+      ar: 'الإسم %1 الفئه %2 القيم %3'
     },
     args1_name: {
       en: 'name',
       es: 'nombre',
-      ar: ''
+      ar: 'الإسم'
     },
     args1_label: {
       en: 'label',
       es: 'etiqueta',
-      ar: ''
+      ar: 'الفئه'
     },
     args1_column: {
       en: 'column',
       es: 'columna',
-      ar: ''
+      ar: 'العمود'
     },
     tooltip: {
       en: 'perform two-sample two-sided t-test',
       es: 'hacer t-test para dos muestras dos colas',
-      ar: ''
+      ar: 'إختبار (ت) ذو الإتجاهين لعينتين'
     }
   }
 }

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -29,117 +29,141 @@ const MSG = {
   create: {
     message0: {
       en: 'Create %1 %2',
-      es: 'Crear %1 %2'
+      es: 'Crear %1 %2',
+      ar: ''
     },
     args0_text: {
       en: 'new_column',
-      es: 'nueva_columna'
+      es: 'nueva_columna',
+      ar: ''
     },
     tooltip: {
       en: 'create new column from existing columns', 
-      es: 'crear nueva columna de las columnas existentes'
+      es: 'crear nueva columna de las columnas existentes',
+      ar: ''
     }
   },
   drop: {
     message0: {
       en: 'Drop %1',
-      es: 'Excluir %1'
+      es: 'Excluir %1',
+      ar: ''
     },
     args0_tooltip: {
       en: 'drop columns by name',
-      es: 'Excluir columnas por nombre'
+      es: 'Excluir columnas por nombre',
+      ar: ''
     }
   },
   filter: {
     message0: {
       en: 'Filter %1', 
-      es: 'Filtrar %1'
+      es: 'Filtrar %1',
+      ar: ''
     },
     args0_name: {
       en: 'TEST', 
-      es: 'TEST'
+      es: 'TEST',
+      ar: ''
     },
     tooltip: {
       en: 'filter rows by condition', 
-      es: 'filtrar filas por condicion'
+      es: 'filtrar filas por condicion',
+      ar: ''
     }
   },
   groupby: {
     message0: {
       en: 'Group by %1', 
-      es: 'Agrupar por %1'
+      es: 'Agrupar por %1',
+      ar: ''
     },
     tooltip: {
       en: 'group data by values in columns', 
-      es: 'agrupar datos por valores en columnas'
+      es: 'agrupar datos por valores en columnas',
+      ar: ''
     }
   },
   report: {
     message0: {
       en: 'Report %1',
-      es: 'Reporte %1'
+      es: 'Reporte %1',
+      ar: ''
     },
     args0_text: {
       en: 'name', 
-      es: 'nombre'
+      es: 'nombre',
+      ar: ''
     },
     tooltip: {
       en: 'report a result', 
-      es: 'reporta un resultado'
+      es: 'reporta un resultado',
+      ar: ''
     }
   },
   select: {
     message0: {
       en: 'Select %1',
-      es: 'Selecciona %1'
+      es: 'Selecciona %1',
+      ar: ''
     },
     tooltip: {
       en: 'select columns by name',
-      es: 'selecciona columnas por nombre'
+      es: 'selecciona columnas por nombre',
+      ar: ''
     }
   },
   sort: {
     message0: {
       en: 'Sort %1 descending %2',
-      es: 'Ordena %1 descendiente %2'
+      es: 'Ordena %1 descendiente %2',
+      ar: ''
     },
     tooltip: {
       en: 'sort table by multiple columns',
-      es: 'ordena tabla por multiples columnas'
+      es: 'ordena tabla por multiples columnas',
+      ar: ''
     }
   },
   summarize: {
     message0: {
       en: 'Summarize %1 %2',
-      es: 'Resumen %1 %2'
+      es: 'Resumen %1 %2',
+      ar: ''
     },
     args0_text: {
       en: 'column', 
-      es: 'columna'
+      es: 'columna',
+      ar: ''
     },
     tooltip: {
       en: 'summarize values in  column',
-      es: 'Resume valores en columna'
+      es: 'Resume valores en columna',
+      ar: ''
     }
   },
   ungroup: {
     message0: {
       en: 'Ungroup',
-      es: 'Desagrupar'
+      es: 'Desagrupar',
+      ar: ''
     },
     tooltip: {
       en: 'remove grouping', 
-      es: 'quita agrupamiento'
+      es: 'quita agrupamiento',
+      ar: ''
     }
   },
   unique: {
     message0: {
       en: 'Unique %1', 
-      es: 'Unico %1'
+      es: 'Unico %1',
+      ar: ''
     },
     tooltip: {
       en: 'select rows with unique values', 
-      es: 'selecciona filas con valores unicos'
+      es: 'selecciona filas con valores unicos',
+      ar: ''
     }
   }
 }

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -24,146 +24,147 @@ const _formatMultiColNames = (raw) => {
 const MSG = {
   multiple_columns: {
     en: 'column, column', 
-    es: 'columna, columna'
+    es: 'columna, columna',
+    ar: 'عمود, عمود'
   },
   create: {
     message0: {
       en: 'Create %1 %2',
       es: 'Crear %1 %2',
-      ar: ''
+      ar: 'إنشاء %1 %2'
     },
     args0_text: {
       en: 'new_column',
       es: 'nueva_columna',
-      ar: ''
+      ar: 'عمود_جديد'
     },
     tooltip: {
       en: 'create new column from existing columns', 
       es: 'crear nueva columna de las columnas existentes',
-      ar: ''
+      ar: 'إنشاء عمود جديد بإستخدام الأعمده الموجوده مسبقا'
     }
   },
   drop: {
     message0: {
       en: 'Drop %1',
       es: 'Excluir %1',
-      ar: ''
+      ar: 'حذف %1'
     },
     args0_tooltip: {
       en: 'drop columns by name',
       es: 'Excluir columnas por nombre',
-      ar: ''
+      ar: 'حذف الأعمده بإستخدام اسمائها'
     }
   },
   filter: {
     message0: {
       en: 'Filter %1', 
       es: 'Filtrar %1',
-      ar: ''
+      ar: 'تصفية أو فلتره %1'
     },
     args0_name: {
       en: 'TEST', 
       es: 'TEST',
-      ar: ''
+      ar: 'إختبار'
     },
     tooltip: {
       en: 'filter rows by condition', 
       es: 'filtrar filas por condicion',
-      ar: ''
+      ar: 'تصفيه أو فلتره الصفوف بإستخدام شرط'
     }
   },
   groupby: {
     message0: {
       en: 'Group by %1', 
       es: 'Agrupar por %1',
-      ar: ''
+      ar: 'تقسيم البيانات عن طريف: %1'
     },
     tooltip: {
       en: 'group data by values in columns', 
       es: 'agrupar datos por valores en columnas',
-      ar: ''
+      ar: 'تقسيم البيانات الى فئات باستخدام قيم الاعمده'
     }
   },
   report: {
     message0: {
       en: 'Report %1',
       es: 'Reporte %1',
-      ar: ''
+      ar: 'التقرير %1'
     },
     args0_text: {
       en: 'name', 
       es: 'nombre',
-      ar: ''
+      ar: 'الإسم'
     },
     tooltip: {
       en: 'report a result', 
       es: 'reporta un resultado',
-      ar: ''
+      ar: 'عرض النتائج'
     }
   },
   select: {
     message0: {
       en: 'Select %1',
       es: 'Selecciona %1',
-      ar: ''
+      ar: 'إختيار %1'
     },
     tooltip: {
       en: 'select columns by name',
       es: 'selecciona columnas por nombre',
-      ar: ''
+      ar: 'إختيار الأعمده بإستخدام اسمائها'
     }
   },
   sort: {
     message0: {
       en: 'Sort %1 descending %2',
       es: 'Ordena %1 descendiente %2',
-      ar: ''
+      ar: 'ترتيب %1 تنازلي %2'
     },
     tooltip: {
       en: 'sort table by multiple columns',
       es: 'ordena tabla por multiples columnas',
-      ar: ''
+      ar: 'ترتيب الجدول بإستخدام اكثر من عمود'
     }
   },
   summarize: {
     message0: {
       en: 'Summarize %1 %2',
       es: 'Resumen %1 %2',
-      ar: ''
+      ar: 'تلخيص البيانات %1 %2'
     },
     args0_text: {
       en: 'column', 
       es: 'columna',
-      ar: ''
+      ar: 'العمود'
     },
     tooltip: {
       en: 'summarize values in  column',
       es: 'Resume valores en columna',
-      ar: ''
+      ar: 'تلخيص قيم العمود'
     }
   },
   ungroup: {
     message0: {
       en: 'Ungroup',
       es: 'Desagrupar',
-      ar: ''
+      ar: 'الغاء التقسيم'
     },
     tooltip: {
       en: 'remove grouping', 
       es: 'quita agrupamiento',
-      ar: ''
+      ar: 'الغاءتقسيم البيانات'
     }
   },
   unique: {
     message0: {
       en: 'Unique %1', 
       es: 'Unico %1',
-      ar: ''
+      ar: 'فريد %1'
     },
     tooltip: {
       en: 'select rows with unique values', 
       es: 'selecciona filas con valores unicos',
-      ar: ''
+      ar: 'إختيار الصفوف ذات القيم الفريده'
     }
   }
 }

--- a/blocks/value.js
+++ b/blocks/value.js
@@ -11,93 +11,111 @@ const MSG = {
   absent: {
     message0: {
       en: 'Absent', 
-      es: 'Ausente'
+      es: 'Ausente',
+      ar: ''
     },
     tooltip: {
       en: 'represent a hole', 
-      es: 'representa un agujero'
+      es: 'representa un agujero',
+      ar: ''
     }
   },
   column: {
     column: {
       en: 'column', 
-      es: 'columna'
+      es: 'columna',
+      ar: ''
     },
     tooltip: {
       en: 'get the value of a column',
-      es: 'obten el valor de una columna'
+      es: 'obten el valor de una columna',
+      ar: ''
     }
   },
   datetime: {
     text: {
       en: 'YYYY-MM-DD',
-      es: 'AAAA-MM-DD' 
+      es: 'AAAA-MM-DD',
+      ar: ''
     },
     tooltip: {
       en: 'constant date/time',
-      es: 'constante fecha/tiempo'
+      es: 'constante fecha/tiempo',
+      ar: ''
     }
   },
   logical: {
     tooltip: {
       en: 'logical constant', 
-      es: 'constante logica'
+      es: 'constante logica',
+      ar: ''
     }
   },
   number: {
     tooltip: {
       en: 'constant number',
-      es: 'numbero constante'
+      es: 'numbero constante',
+      ar: ''
     }
   },
   text: {
     text: {
       en: 'text',
-      es: 'texto'
+      es: 'texto',
+      ar: ''
     },
     tooltip: {
       en: 'constant text', 
-      es: 'texto constante'
+      es: 'texto constante',
+      ar: ''
     }
   },
   rownum: {
     message0: {
       en: 'Row number',
-      es: 'Numero de fila'
+      es: 'Numero de fila',
+      ar: ''
     },
     tooltip: {
       en: 'row number',
-      es: 'numero de fila'
+      es: 'numero de fila',
+      ar: ''
     }
   },
   exponential: {
     message0: {
       en: 'Exponential \u03BB %1',
-      es: 'Exponencial \u03BB %1'
+      es: 'Exponencial \u03BB %1',
+      ar: ''
     },
     tooltip: {
       en: 'exponential random value',
-      es: 'valor aleatorio exponencial'
+      es: 'valor aleatorio exponencial',
+      ar: ''
     }
   },
   normal: {
     message0: {
       en: 'Normal \u03BC %1 \u03C3 %2',
-      es: 'Normal \u03BC %1 \u03C3 %2'
+      es: 'Normal \u03BC %1 \u03C3 %2',
+      ar: ''
     },
     tooltip: {
       en: 'normal random value',
-      es: 'valor aleatorio normal'
+      es: 'valor aleatorio normal',
+      ar: ''
     }
   },
   uniform: {
     message0: {
       en: 'Uniform \u03B1 %1 \u03B2 %2', 
-      es: 'Uniforme \u03B1 %1 \u03B2 %2'
+      es: 'Uniforme \u03B1 %1 \u03B2 %2',
+      ar: ''
     },
     tooltip: {
       en: 'uniform random value', 
-      es: 'valor aleatorio uniforme'
+      es: 'valor aleatorio uniforme',
+      ar: ''
     }
   }
 }

--- a/blocks/value.js
+++ b/blocks/value.js
@@ -12,110 +12,110 @@ const MSG = {
     message0: {
       en: 'Absent', 
       es: 'Ausente',
-      ar: ''
+      ar: 'غائب'
     },
     tooltip: {
       en: 'represent a hole', 
       es: 'representa un agujero',
-      ar: ''
+      ar: 'تمثيل فجوه'
     }
   },
   column: {
     column: {
       en: 'column', 
       es: 'columna',
-      ar: ''
+      ar: 'العمود'
     },
     tooltip: {
       en: 'get the value of a column',
       es: 'obten el valor de una columna',
-      ar: ''
+      ar: 'الحصول على قيمه من عمود'
     }
   },
   datetime: {
     text: {
       en: 'YYYY-MM-DD',
       es: 'AAAA-MM-DD',
-      ar: ''
+      ar: 'YYYY-MM-DD'
     },
     tooltip: {
       en: 'constant date/time',
       es: 'constante fecha/tiempo',
-      ar: ''
+      ar: 'ثابت تاريخ/وقت'
     }
   },
   logical: {
     tooltip: {
       en: 'logical constant', 
       es: 'constante logica',
-      ar: ''
+      ar: 'ثابت منطقي'
     }
   },
   number: {
     tooltip: {
       en: 'constant number',
       es: 'numbero constante',
-      ar: ''
+      ar: 'رقم ثابت'
     }
   },
   text: {
     text: {
       en: 'text',
       es: 'texto',
-      ar: ''
+      ar: 'نص'
     },
     tooltip: {
       en: 'constant text', 
       es: 'texto constante',
-      ar: ''
+      ar: 'نص ثابت'
     }
   },
   rownum: {
     message0: {
       en: 'Row number',
       es: 'Numero de fila',
-      ar: ''
+      ar: 'رقم الصف'
     },
     tooltip: {
       en: 'row number',
       es: 'numero de fila',
-      ar: ''
+      ar: 'رقم الصف'
     }
   },
   exponential: {
     message0: {
       en: 'Exponential \u03BB %1',
       es: 'Exponencial \u03BB %1',
-      ar: ''
+      ar: 'الأسيه \u03BB %1'
     },
     tooltip: {
       en: 'exponential random value',
       es: 'valor aleatorio exponencial',
-      ar: ''
+      ar: 'المتغيرات العشوائه الأسيه'
     }
   },
   normal: {
     message0: {
       en: 'Normal \u03BC %1 \u03C3 %2',
       es: 'Normal \u03BC %1 \u03C3 %2',
-      ar: ''
+      ar: 'الطبيعي \u03BC %1 \u03C3 %2'
     },
     tooltip: {
       en: 'normal random value',
       es: 'valor aleatorio normal',
-      ar: ''
+      ar: 'المتغير العشوائي الطبيعي'
     }
   },
   uniform: {
     message0: {
       en: 'Uniform \u03B1 %1 \u03B2 %2', 
       es: 'Uniforme \u03B1 %1 \u03B2 %2',
-      ar: ''
+      ar: 'المنتظم \u03B1 %1 \u03B2 %2'
     },
     tooltip: {
       en: 'uniform random value', 
       es: 'valor aleatorio uniforme',
-      ar: ''
+      ar: 'المتغير العشوائي المنتظم'
     }
   }
 }


### PR DESCRIPTION
I added the Arabic translation for the plot.js file. 
Note: When ending an Arabic line with a symbol (e.g. %,|,! or .), it automatically comes to the front of that line (the far right, instead of the far left). This always happens when merging English and Arabic on the same line. My suggestion to this is to end the Arabic lines where this happens with a meaningful word after the symbol. 