### PR TITLE
Updating unnamed reports

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -320,7 +320,7 @@ const createXmlConfig = (language) => {
       <block type="transform_drop"></block>
       <block type="transform_filter"></block>
       <block type="transform_groupBy"></block>
-      <block type="transform_report"></block>
+      <block type="transform_saveAs"></block>
       <block type="transform_select"></block>
       <block type="transform_sort"></block>
       <block type="transform_summarize"></block>

--- a/blocks/helpers.js
+++ b/blocks/helpers.js
@@ -9,6 +9,20 @@ const Blockly = require('blockly/blockly_compressed')
 const ORDER_NONE = 0
 
 /**
+ * Helper function to turn a string containing comma-separated column names into
+ * an array of JavaScript strings.
+ */
+const formatMultiColNames = (raw) => {
+  const joined = raw
+    .split(',')
+    .map(c => c.trim())
+    .filter(c => (c.length > 0))
+    .map(c => `"${c}"`)
+    .join(', ')
+  return `[${joined}]`
+}
+
+/**
  * Get the value of a sub-block as text or an 'absent' placeholder if the
  * sub-block is missing.
  * @param block The block object.
@@ -71,6 +85,7 @@ Messages.UNDEFINED = 'undefined'
 
 module.exports = {
   ORDER_NONE,
+  formatMultiColNames,
   valueToCode,
   Messages
 }

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -3,23 +3,10 @@
 const Blockly = require('blockly/blockly_compressed')
 
 const {
+  formatMultiColNames,
   valueToCode,
   Messages
 } = require('./helpers')
-
-/**
- * Helper function to turn a string containing comma-separated column names into
- * an array of JavaScript strings.
- */
-const _formatMultiColNames = (raw) => {
-  const joined = raw
-    .split(',')
-    .map(c => c.trim())
-    .filter(c => (c.length > 0))
-    .map(c => `"${c}"`)
-    .join(', ')
-  return `[${joined}]`
-}
 
 /**
  * Lookup table for message strings.
@@ -85,7 +72,7 @@ const MESSAGES = {
       ko: '조건에 따라 행 거르기'
     }
   },
-  groupby: {
+  groupBy: {
     message0: {
       en: 'Group by %1', 
       es: 'Agrupar por %1',
@@ -99,12 +86,12 @@ const MESSAGES = {
       ko: '열의 값들로 데이터 그룹화'
     }
   },
-  report: {
+  saveAs: {
     message0: {
-      en: 'Report %1',
-      es: 'Reporte %1',
-      ar: 'التقرير %1',
-      ko: '%1 리포트'
+      en: 'Save as %1',
+      es: 'Reporte %1', // TRANSLATE ES
+      ar: 'التقرير %1', // TRANSLATE AR
+      ko: '%1 리포트' // TRANSLATE KO
     },
     args0_text: {
       en: 'name', 
@@ -113,10 +100,10 @@ const MESSAGES = {
       ko: '이름'
     },
     tooltip: {
-      en: 'report a result', 
-      es: 'reporta un resultado',
-      ar: 'عرض النتائج',
-      ko: '결과 리포트'
+      en: 'save a result',
+      es: 'reporta un resultado', // TRANSLATE ES
+      ar: 'عرض النتائج', // TRANSLATE AR
+      ko: '결과 리포트' // TRANSLATE KO
     }
   },
   select: {
@@ -269,7 +256,7 @@ const setup = (language) => {
     // Group
     {
       type: 'transform_groupBy',
-      message0: msg.get('groupby.message0'),
+      message0: msg.get('groupBy.message0'),
       args0: [
         {
           type: 'field_input',
@@ -281,26 +268,26 @@ const setup = (language) => {
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: msg.get('groupby.tooltip'),
+      tooltip: msg.get('groupBy.tooltip'),
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
 
-    // Report
+    // Save As
     {
-      type: 'transform_report',
-      message0: msg.get('report.message0'),
+      type: 'transform_saveAs',
+      message0: msg.get('saveAs.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: msg.get('report.args0_text')
+          text: msg.get('saveAs.args0_text')
         }
       ],
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: msg.get('report.tooltip'),
+      tooltip: msg.get('saveAs.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME']
     },
@@ -429,7 +416,7 @@ const setup = (language) => {
 
   // Drop
   Blockly.TidyBlocks['transform_drop'] = (block) => {
-    const columns = _formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
+    const columns = formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
     return `["@transform", "drop", ${columns}]`
   }
 
@@ -441,25 +428,25 @@ const setup = (language) => {
 
   // Group
   Blockly.TidyBlocks['transform_groupBy'] = (block) => {
-    const columns = _formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
+    const columns = formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
     return `["@transform", "groupBy", ${columns}]`
   }
 
   // Report
-  Blockly.TidyBlocks['transform_report'] = (block) => {
+  Blockly.TidyBlocks['transform_saveAs'] = (block) => {
     const name = block.getFieldValue('NAME')
-    return `["@transform", "report", "${name}"]`
+    return `["@transform", "saveAs", "${name}"]`
   }
 
   // Select
   Blockly.TidyBlocks['transform_select'] = (block) => {
-    const columns = _formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
+    const columns = formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
     return `["@transform", "select", ${columns}]`
   }
 
   // Sort
   Blockly.TidyBlocks['transform_sort'] = (block) => {
-    const columns = _formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
+    const columns = formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
     const descending = (block.getFieldValue('DESCENDING') === 'TRUE')
     return `["@transform", "sort", ${columns}, ${descending}]`
   }
@@ -478,7 +465,7 @@ const setup = (language) => {
 
   // Unique
   Blockly.TidyBlocks['transform_unique'] = (block) => {
-    const columns = _formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
+    const columns = formatMultiColNames(block.getFieldValue('MULTIPLE_COLUMNS'))
     return `["@transform", "unique", ${columns}]`
   }
 }

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -26,7 +26,7 @@ const _formatMultiColNames = (raw) => {
  */
 const MESSAGES = {
   multiple_columns: {
-    en: 'column, column', 
+    en: 'column, column',
     es: 'columna, columna'
   },
   create: {
@@ -39,7 +39,7 @@ const MESSAGES = {
       es: 'nueva_columna'
     },
     tooltip: {
-      en: 'create new column from existing columns', 
+      en: 'create new column from existing columns',
       es: 'crear nueva columna de las columnas existentes'
     }
   },
@@ -55,39 +55,39 @@ const MESSAGES = {
   },
   filter: {
     message0: {
-      en: 'Filter %1', 
+      en: 'Filter %1',
       es: 'Filtrar %1'
     },
     args0_name: {
-      en: 'TEST', 
+      en: 'TEST',
       es: 'TEST'
     },
     tooltip: {
-      en: 'filter rows by condition', 
+      en: 'filter rows by condition',
       es: 'filtrar filas por condicion'
     }
   },
   groupby: {
     message0: {
-      en: 'Group by %1', 
+      en: 'Group by %1',
       es: 'Agrupar por %1'
     },
     tooltip: {
-      en: 'group data by values in columns', 
+      en: 'group data by values in columns',
       es: 'agrupar datos por valores en columnas'
     }
   },
-  report: {
+  saveas: {
     message0: {
-      en: 'Report %1',
+      en: 'Save As %1',
       es: 'Reporte %1'
     },
     args0_text: {
-      en: 'name', 
+      en: 'name',
       es: 'nombre'
     },
     tooltip: {
-      en: 'report a result', 
+      en: 'save a result',
       es: 'reporta un resultado'
     }
   },
@@ -117,7 +117,7 @@ const MESSAGES = {
       es: 'Resumen %1 %2'
     },
     args0_text: {
-      en: 'column', 
+      en: 'column',
       es: 'columna'
     },
     tooltip: {
@@ -131,17 +131,17 @@ const MESSAGES = {
       es: 'Desagrupar'
     },
     tooltip: {
-      en: 'remove grouping', 
+      en: 'remove grouping',
       es: 'quita agrupamiento'
     }
   },
   unique: {
     message0: {
-      en: 'Unique %1', 
+      en: 'Unique %1',
       es: 'Unico %1'
     },
     tooltip: {
-      en: 'select rows with unique values', 
+      en: 'select rows with unique values',
       es: 'selecciona filas con valores unicos'
     }
   }
@@ -236,21 +236,21 @@ const setup = (language) => {
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
 
-    // Report
+    // Save As
     {
-      type: 'transform_report',
-      message0: msg.get('report.message0'),
+      type: 'transform_saveAs',
+      message0: msg.get('saveas.message0'),
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: msg.get('report.args0_text')
+          text: msg.get('saveas.args0_text')
         }
       ],
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: msg.get('report.tooltip'),
+      tooltip: msg.get('saveAs.tooltip'),
       helpUrl: '',
       extensions: ['validate_NAME']
     },
@@ -396,9 +396,9 @@ const setup = (language) => {
   }
 
   // Report
-  Blockly.TidyBlocks['transform_report'] = (block) => {
+  Blockly.TidyBlocks['transform_saveAs'] = (block) => {
     const name = block.getFieldValue('NAME')
-    return `["@transform", "report", "${name}"]`
+    return `["@transform", "saveAs", "${name}"]`
   }
 
   // Select

--- a/libs/env.js
+++ b/libs/env.js
@@ -19,6 +19,7 @@ class Env {
     this.plots = new Map()
     this.stats = new Map()
     this.log = []
+    this.unnamedCounter = 0
   }
 
   /**
@@ -116,6 +117,15 @@ class Env {
     util.check(level && (typeof level === 'string') && Env.LOG_LEVELS.has(level),
                `Invalid or unknown log level "${level}"`)
     this.log.push([level, message])
+  }
+
+  /**
+   * Get the serial number of the next unnamed result.
+   * @returns {number} Unique serial number of next unnamed result.
+   */
+  getNextUnnamedId () {
+    this.unnamedCounter += 1
+    return this.unnamedCounter
   }
 }
 

--- a/libs/pipeline.js
+++ b/libs/pipeline.js
@@ -2,6 +2,7 @@
 
 const util = require('./util')
 const Transform = require('./transform')
+let unnamedCounter = 1
 
 /**
  * Manage a single pipeline.
@@ -52,8 +53,21 @@ class Pipeline {
 
     let data = null
     for (const transform of this.transforms) {
+      console.log(transform)
       data = transform.run(env, data)
     }
+
+    // If the last block of the pipeline is not a report we'll report it as an
+    // unamed result.
+    if (!(this.transforms[this.transforms.length - 1] instanceof Transform.saveAs)
+      && !(this.transforms[this.transforms.length - 1] instanceof Transform.plot)
+      && !(this.transforms[this.transforms.length - 1] instanceof Transform.stats)){
+      data = new Transform.saveAs("unnamed " + unnamedCounter).run(env, data)
+      unnamedCounter = unnamedCounter + 1
+    }
+
+    console.log("running pipe")
+    console.log(data)
   }
 }
 

--- a/libs/pipeline.js
+++ b/libs/pipeline.js
@@ -2,7 +2,6 @@
 
 const util = require('./util')
 const Transform = require('./transform')
-let unnamedCounter = 1
 
 /**
  * Manage a single pipeline.
@@ -38,8 +37,12 @@ class Pipeline {
    * Run this pipeline.
    * @param {Env} env The runtime environment. This is filled with results,
    * statistics, and plots as a side effect of running certain blocks.
+   * @param {int} unnamedCounter The number used to label any unnamed results
+   * we display.
+   * @returns {int} the unnamedCounter, updated if a new unnaamed result was
+   * reported.
    */
-  run (env) {
+  run (env, unnamedCounter) {
     util.check(Array.isArray(this.transforms) &&
                (this.transforms.length > 0) &&
                this.transforms.every(transform => transform instanceof Transform.base),
@@ -53,21 +56,18 @@ class Pipeline {
 
     let data = null
     for (const transform of this.transforms) {
-      console.log(transform)
       data = transform.run(env, data)
     }
 
-    // If the last block of the pipeline is not a report we'll report it as an
-    // unamed result.
+    // If the last block of the pipeline is not a report, plot result, or stats
+    // result we'll report it as an unnamed result.
     if (!(this.transforms[this.transforms.length - 1] instanceof Transform.saveAs)
       && !(this.transforms[this.transforms.length - 1] instanceof Transform.plot)
       && !(this.transforms[this.transforms.length - 1] instanceof Transform.stats)){
       data = new Transform.saveAs("unnamed " + unnamedCounter).run(env, data)
       unnamedCounter = unnamedCounter + 1
     }
-
-    console.log("running pipe")
-    console.log(data)
+    return unnamedCounter
   }
 }
 

--- a/libs/pipeline.js
+++ b/libs/pipeline.js
@@ -37,8 +37,12 @@ class Pipeline {
    * Run this pipeline.
    * @param {Env} env The runtime environment. This is filled with results,
    * statistics, and plots as a side effect of running certain blocks.
+   * @param {int} unnamedCounter The number used to label any unnamed results
+   * we display.
+   * @returns {int} the unnamedCounter, updated if a new unnaamed result was
+   * reported.
    */
-  run (env) {
+  run (env, unnamedCounter) {
     util.check(Array.isArray(this.transforms) &&
                (this.transforms.length > 0) &&
                this.transforms.every(transform => transform instanceof Transform.base),
@@ -54,6 +58,16 @@ class Pipeline {
     for (const transform of this.transforms) {
       data = transform.run(env, data)
     }
+
+    // If the last block of the pipeline is not a report, plot result, or stats
+    // result we'll report it as an unnamed result.
+    if (!(this.transforms[this.transforms.length - 1] instanceof Transform.saveAs)
+      && !(this.transforms[this.transforms.length - 1] instanceof Transform.plot)
+      && !(this.transforms[this.transforms.length - 1] instanceof Transform.stats)){
+      data = new Transform.saveAs("unnamed " + unnamedCounter).run(env, data)
+      unnamedCounter = unnamedCounter + 1
+    }
+    return unnamedCounter
   }
 }
 

--- a/libs/program.js
+++ b/libs/program.js
@@ -16,12 +16,15 @@ class Program {
    * - `waiting` maps sets of dependency names to runnable pipelines, and is
    *   used to keep track of pipelines that are waiting for other things to
    *   finish.
+   * - `unnamedCounter` tracks how many unnamed results have been reported 
+   *   for for labelling purposes.
    */
   constructor (...pipelines) {
     this.env = null
     this.pipelines = []
     this.queue = []
     this.waiting = new Map()
+    this.unnamedCounter = 1
 
     pipelines.forEach(pipeline => this.register(pipeline))
   }
@@ -83,13 +86,14 @@ class Program {
    * @param {Env} env The runtime environment of the program.
    */
   run (env) {
+    this.unnamedCounter = 1
     this.env = env
     try {
       // Run until queue is empty.
       while (this.queue.length > 0) {
         const pipeline = this.queue.shift()
         const previous = new Set(this.env.results.keys())
-        pipeline.run(this.env)
+        this.unnamedCounter = pipeline.run(this.env, this.unnamedCounter)
         Array.from(this.env.results.keys())
           .filter(key => !previous.has(key))
           .forEach(key => this.notify(key))

--- a/libs/transform.js
+++ b/libs/transform.js
@@ -241,9 +241,9 @@ class TransformJoin extends TransformBase {
 
 /**
  * Report that a result is available.
- * @param {string} label Name to use for reported value.
+ * @param {string} label Name to use for saved value.
  */
-class TransformReport extends TransformBase {
+class TransformSaveAs extends TransformBase {
   constructor (label) {
     util.check(typeof label === 'string',
                `Expected string`)
@@ -593,13 +593,21 @@ class TransformScatter extends TransformPlot {
 }
 
 // ----------------------------------------------------------------------
+/**
+ * Base class for identifying our stats transforms.
+ */
+class TransformStats extends TransformBase {
+  constructor (species, requires, input, output) {
+    super(species, requires, input, output)
+  }
+}
 
 /**
  * One-sample two-sided t-test.
  * @param {string} colName The column to get values from.
  * @param {number} mean Mean value tested for.
  */
-class TransformTTestOneSample extends TransformBase {
+class TransformTTestOneSample extends TransformStats {
   constructor (label, colName, mean) {
     super('ttest_one', [], true, true)
     this.label = label
@@ -622,7 +630,7 @@ class TransformTTestOneSample extends TransformBase {
  * @param {string} labelCol The column to get labels from.
  * @param {string} valueCol The column to get the values from.
  */
-class TransformTTestPaired extends TransformBase {
+class TransformTTestPaired extends TransformStats {
   constructor (label, labelCol, valueCol) {
     super('ttest_two', [], true, true)
     this.label = label
@@ -661,18 +669,20 @@ module.exports = {
   glue: TransformGlue,
   groupBy: TransformGroupBy,
   join: TransformJoin,
-  report: TransformReport,
+  saveAs: TransformSaveAs,
   select: TransformSelect,
   sequence: TransformSequence,
   sort: TransformSort,
   summarize: TransformSummarize,
   ungroup: TransformUngroup,
   unique: TransformUnique,
+  plot: TransformPlot,
   bar: TransformBar,
   box: TransformBox,
   dot: TransformDot,
   histogram: TransformHistogram,
   scatter: TransformScatter,
+  stats: TransformStats,
   ttest_one: TransformTTestOneSample,
-  ttest_two: TransformTTestPaired
+  ttest_two: TransformTTestPaired,
 }

--- a/libs/transform.js
+++ b/libs/transform.js
@@ -21,9 +21,9 @@ class TransformBase {
    * @param {string} species What this transform is called.
    * @param {string[]} requires What datasets are required before this can run?
    * @param {Boolean} input Does this transform require input?
-   * @param {Boolean} output Does this transform produce output?
+   * @param {Boolean} savesResult Does this transform automatically save its result in the environment?
    */
-  constructor (species, requires, input, output) {
+  constructor (species, requires, input, savesResult) {
     util.check(species && (typeof species === 'string') &&
                Array.isArray(requires) &&
                requires.every(x => (typeof x === 'string')),
@@ -31,7 +31,7 @@ class TransformBase {
     this.species = species
     this.requires = requires
     this.input = input
-    this.output = output
+    this.savesResult = savesResult
   }
 
   equal (other) {
@@ -64,7 +64,7 @@ class TransformCreate extends TransformBase {
                `Expected string as new name`)
     util.check(expr instanceof ExprBase,
                `Expected expression`)
-    super('create', [], true, true)
+    super('create', [], true, false)
     this.newName = newName
     this.expr = expr
   }
@@ -89,7 +89,7 @@ class TransformData extends TransformBase {
   constructor (name) {
     util.check(typeof name === 'string',
                `Expected string`)
-    super('read', [], false, true)
+    super('read', [], false, false)
     this.name = name
   }
 
@@ -114,7 +114,7 @@ class TransformDrop extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('drop', [], true, true)
+    super('drop', [], true, false)
     this.columns = columns
   }
 
@@ -136,7 +136,7 @@ class TransformFilter extends TransformBase {
   constructor (expr) {
     util.check(expr instanceof ExprBase,
                `Expected expression`)
-    super('filter', [], true, true)
+    super('filter', [], true, false)
     this.expr = expr
   }
 
@@ -159,7 +159,7 @@ class TransformFilter extends TransformBase {
  */
 class TransformGlue extends TransformBase {
   constructor (leftName, rightName, label) {
-    super('glue', [leftName, rightName], false, true)
+    super('glue', [leftName, rightName], false, false)
     this.leftName = leftName
     this.rightName = rightName
     this.label = label
@@ -190,7 +190,7 @@ class TransformGroupBy extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('groupBy', [], true, true)
+    super('groupBy', [], true, false)
     this.columns = columns
   }
 
@@ -213,7 +213,7 @@ class TransformGroupBy extends TransformBase {
  */
 class TransformJoin extends TransformBase {
   constructor (leftName, leftCol, rightName, rightCol) {
-    super('join', [leftName, rightName], false, true)
+    super('join', [leftName, rightName], false, false)
     this.leftName = leftName
     this.leftCol = leftCol
     this.rightName = rightName
@@ -271,7 +271,7 @@ class TransformSelect extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('select', [], true, true)
+    super('select', [], true, false)
     this.columns = columns
   }
 
@@ -294,7 +294,7 @@ class TransformSequence extends TransformBase {
   constructor (newName, limit) {
     util.check(typeof newName === 'string',
                `Expected string as new name`)
-    super('sequence', [], true, true)
+    super('sequence', [], true, false)
     this.newName = newName
     this.limit = limit
   }
@@ -329,7 +329,7 @@ class TransformSort extends TransformBase {
                `Expected array of columns`)
     util.check(typeof reverse === 'boolean',
                `Expected Boolean`)
-    super('sort', [], true, true)
+    super('sort', [], true, false)
     this.columns = columns
     this.reverse = reverse
   }
@@ -357,7 +357,7 @@ class TransformSummarize extends TransformBase {
                `Unknown summarization operation ${action}`)
     util.check(typeof column === 'string',
                `Expected string as column name`)
-    super('summarize', [], true, true)
+    super('summarize', [], true, false)
     this.action = action
     this.column = column
   }
@@ -379,7 +379,7 @@ class TransformSummarize extends TransformBase {
  */
 class TransformUngroup extends TransformBase {
   constructor () {
-    super('ungroup', [], true, true)
+    super('ungroup', [], true, false)
   }
 
   run (env, df) {
@@ -396,7 +396,7 @@ class TransformUnique extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('unique', [], true, true)
+    super('unique', [], true, false)
     this.columns = columns
   }
 
@@ -597,8 +597,8 @@ class TransformScatter extends TransformPlot {
  * Base class for identifying our stats transforms.
  */
 class TransformStats extends TransformBase {
-  constructor (species, requires, input, output) {
-    super(species, requires, input, output)
+  constructor (species, requires, input) {
+    super(species, [], true, true)
   }
 }
 
@@ -609,7 +609,7 @@ class TransformStats extends TransformBase {
  */
 class TransformTTestOneSample extends TransformStats {
   constructor (label, colName, mean) {
-    super('ttest_one', [], true, true)
+    super('ttest_one')
     this.label = label
     this.colName = colName
     this.mean = mean
@@ -632,7 +632,7 @@ class TransformTTestOneSample extends TransformStats {
  */
 class TransformTTestPaired extends TransformStats {
   constructor (label, labelCol, valueCol) {
-    super('ttest_two', [], true, true)
+    super('ttest_two')
     this.label = label
     this.labelCol = labelCol
     this.valueCol = valueCol

--- a/libs/ui/select.jsx
+++ b/libs/ui/select.jsx
@@ -43,7 +43,6 @@ export const DataTabSelect = ({options, onChange, value}) => (
   <Select className="sourceSelect" classNamePrefix="sourceSelectInner"
     options={options}
     value={value}
-    styles={colourStyles}
     onChange={(e) => onChange(e)}
   />
 )

--- a/libs/ui/tabs.jsx
+++ b/libs/ui/tabs.jsx
@@ -103,6 +103,20 @@ export function TabSelectionBar (props) {
             </Animated>
           </div>
         }/>
+        <Tab {...a11yProps(props.resultsIndex)}
+          label={
+            <div className="tabWrapper">
+              <span className="dotPadding"></span>
+              Results
+              <Animated
+                animationIn="fadeIn"
+                animationOut="fadeOut"
+                animateOnMount={false}
+                isVisible={props.tabUpdated.results}>
+                  <span className="dotIndicator defaultDotIndicator"></span>
+              </Animated>
+            </div>
+          }/>
       <Tab {...a11yProps(props.statsIndex)}
         label={
           <div className="tabWrapper">
@@ -187,7 +201,42 @@ export function TabPanels (props) {
           </div>
         </Animated>
       </TabPanel>
-      <TabPanel value={props.tabValue} index={1}>
+      <TabPanel value={props.tabValue} index={1} component="div">
+        <TabHeader
+          maximizePanel={props.maximizePanel}
+          minimizePanel={props.minimizePanel}
+          restorePanel={props.restorePanel}
+          selectDropdown={props.resultsDropdown}/>
+        <Animated
+          animationIn="fadeIn"
+          animationOut="fadeOut"
+          animationInDuration={800}
+          animationOutDuration={800}
+          >
+          <div className="relativeWrapper">
+            <div className="dataWrapper">
+              {props.resultColumns &&
+                <Animated
+                  animationIn="fadeIn"
+                  animationOut="fadeOut"
+                  animationInDuration={800}
+                  animationOutDuration={800}
+                  isVisible={!props.hideResultTable}>
+                  <DataGrid
+                    ref={props.resultGridRef}
+                    columns={props.resultColumns}
+                    rows={props.results}
+                    enableCellAutoFocus={false}
+                    height={props.topRightPaneHeight}
+                    onGridSort={props.sortRows}
+                    />
+                </Animated>
+              }
+            </div>
+          </div>
+        </Animated>
+      </TabPanel>
+      <TabPanel value={props.tabValue} index={2}>
         <TabHeader maximizePanel={props.maximizePanel}
           minimizePanel={props.minimizePanel}
           restorePanel={props.restorePanel}
@@ -230,7 +279,7 @@ export function TabPanels (props) {
           }
         </Animated>
       </TabPanel>
-      <TabPanel value={props.tabValue} index={2} component="div">
+      <TabPanel value={props.tabValue} index={3} component="div">
         <TabHeader maximizePanel={props.maximizePanel}
           minimizePanel={props.minimizePanel}
           restorePanel={props.restorePanel}
@@ -256,7 +305,7 @@ export function TabPanels (props) {
           </div>
         </Animated>
       </TabPanel>
-      <TabPanel value={props.tabValue} index={3}>
+      <TabPanel value={props.tabValue} index={4}>
         <TabHeader maximizePanel={props.maximizePanel}
           minimizePanel={props.minimizePanel}
           restorePanel={props.restorePanel}

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -47,6 +47,7 @@ export class TidyBlocksApp extends React.Component {
     this.blocklyRef = React.createRef()
     this.plotOutputRef = React.createRef()
     this.dataGridRef = React.createRef()
+    this.resultGridRef = React.createRef()
     this.workspaceFileUploader = React.createRef()
     this.csvFileUploader = React.createRef()
     this.saveCsvNameDialog = React.createRef()
@@ -64,14 +65,16 @@ export class TidyBlocksApp extends React.Component {
       tabValue: 0,
       tabUpdated: {
         'data': false,
+        'results': false,
         'stats': false,
         'plot': false,
         'console': false
       },
       DATA_TAB_INDEX: 0,
-      STATS_TAB_INDEX: 1,
-      PLOT_TAB_INDEX: 2,
-      CONSOLE_TAB_INDEX: 3,
+      RESULTS_TAB_INDEX: 1,
+      STATS_TAB_INDEX: 2,
+      PLOT_TAB_INDEX: 3,
+      CONSOLE_TAB_INDEX: 4,
       CONSOLE_SUCCESS: 'CONSOLE_SUCCESS',
       CONSOLE_WARNING: 'CONSOLE_WARNING',
       CONSOLE_ERROR: 'CONSOLE_ERROR',
@@ -89,6 +92,14 @@ export class TidyBlocksApp extends React.Component {
       dataValue: null,
       activeDataOption: null,
       hideDataTable: false,
+
+      resultKeys: null,
+      results: null,
+      resultColumns: null,
+      resultOptions: [],
+      resultValue: null,
+      activeResultOption: null,
+      hideResultTable: false,
 
       plotKeys: null,
       plotData: null,
@@ -116,6 +127,7 @@ export class TidyBlocksApp extends React.Component {
     this.loadCsv = this.loadCsv.bind(this)
     this.loadCsvUrl = this.loadCsvUrl.bind(this)
     this.changeData = this.changeData.bind(this)
+    this.changeResults = this.changeResults.bind(this)
     this.changeStats = this.changeStats.bind(this)
     this.handleTabChange = this.handleTabChange.bind(this)
     this.sortRows = this.sortRows.bind(this)
@@ -282,23 +294,25 @@ export class TidyBlocksApp extends React.Component {
   changeData (e) {
     const activeDataOption = e
     let formattedColumns = []
+    const data = this.state.env.ui.userData.get(activeDataOption.label)['data']
+    const dataColumns = this.state.env.ui.userData.get(activeDataOption.label)['columns']
+    dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
+    this.setState({activeDataOption: activeDataOption, data: data,
+      dataColumns: formattedColumns})
+  }
+
+  changeResults (e) {
+    const activeResultOption = e
+    let formattedColumns = []
     // Swap the stored data depending on whether we're showing userData or
     // results.
-    if (activeDataOption.type == DATA_USER){
-      const data = this.state.env.ui.userData.get(activeDataOption.label)['data']
-      const dataColumns = this.state.env.ui.userData.get(activeDataOption.label)['columns']
-      dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
-      this.setState({activeDataOption: activeDataOption, data: data,
-        dataColumns: formattedColumns})
-
-    } else if (activeDataOption.type == DATA_REPORT){
-      const data = this.state.env.results.get(activeDataOption.label)['data']
-      const dataColumns = this.state.env.results.get(activeDataOption.label)['columns']
-      dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
-      this.setState({activeDataOption: activeDataOption, data: data,
-        dataColumns: formattedColumns})
-    }
+    const results = this.state.env.results.get(activeResultOption.label)['data']
+    const resultColumns = this.state.env.results.get(activeResultOption.label)['columns']
+    resultColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
+    this.setState({activeResultOption: activeResultOption, results: results,
+      resultColumns: formattedColumns})
   }
+
 
   changeStats (e) {
     const activeStatsOption = e
@@ -358,7 +372,10 @@ export class TidyBlocksApp extends React.Component {
   runProgram () {
     TidyBlocksUI.runProgram()
     const env = TidyBlocksUI.env
+    console.log('env')
+    console.log(env)
     this.updateDataInformation(env)
+    this.updateResultsInformation(env)
     this.updatePlotInformation(env)
     this.updateStatsInformation(env)
     this.updateLogMessages(env)
@@ -373,21 +390,14 @@ export class TidyBlocksApp extends React.Component {
     // If the active data option no longer exists remove it. This happens
     // when the currently displayed table has been deleted or renamed.
     if (this.state.activeDataOption) {
-      if (!(env.ui.userData.has(this.state.activeDataOption.label)
-        || env.results.has(this.state.activeDataOption.label))){
+      if (!(env.ui.userData.has(this.state.activeDataOption.label))){
         this.state.activeDataOption = null
       }
     }
     if (this.state.activeDataOption) {
-      // Swap the stored data depending on whether we're showing userData or
-      // results.
       if (this.state.activeDataOption.type == DATA_USER){
         data = env.ui.userData.get(this.state.activeDataOption.label)['data']
         dataColumns = env.ui.userData.get(this.state.activeDataOption.label)['columns']
-        dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
-      } else if (this.state.activeDataOption.type == DATA_REPORT){
-        data = env.results.get(this.state.activeDataOption.label)['data']
-        dataColumns = env.results.get(this.state.activeDataOption.label)['columns']
         dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
       }
       activeDataOption = this.state.activeDataOption
@@ -404,9 +414,7 @@ export class TidyBlocksApp extends React.Component {
     for (let key of env.ui.userData.keys()){
       dataOptions.push({value: DATA_USER + '_' + key, type: DATA_USER, label: key})
     }
-    for (let key of env.results.keys()){
-      dataOptions.push({value: DATA_REPORT + '_' + key, type: DATA_REPORT, label: key})
-    }
+
     // Indicate the tab was updated if it has been.
     let tabUpdated = this.state.tabUpdated
     if (data && data != this.state.data && this.state.tabValue != this.state.DATA_TAB_INDEX){
@@ -416,6 +424,52 @@ export class TidyBlocksApp extends React.Component {
       activeDataOption: activeDataOption, dataOptions: dataOptions,
       tabUpdated: tabUpdated})
   }
+
+  updateResultsInformation (env) {
+    const resultKeys = env.results.keys()
+    let results = null
+    let resultColumns = null
+    let activeResultOption = null
+    let formattedColumns = []
+
+    // If the active data option no longer exists remove it. This happens
+    // when the currently displayed table has been deleted or renamed.
+    if (this.state.activeResultOption) {
+      if (!(env.results.has(this.state.activeResultOption.label)
+        || env.results.has(this.state.activeResultOption.label))){
+        this.state.activeResultOption = null
+      }
+    }
+    if (this.state.activeResultOption) {
+      results = env.results.get(this.state.activeResultOption.label)['data']
+      resultColumns = env.results.get(this.state.activeResultOption.label)['columns']
+      resultColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
+      activeResultOption = this.state.activeResultOption
+    } else {
+      let result = resultKeys.next()
+      if (!result.done){
+        activeResultOption = {value: DATA_USER + '_' + result.value, type: DATA_USER, label: result.value}
+        results = env.results.get(activeResultOption.label)['data']
+        resultColumns = env.results.get(activeResultOption.label)['columns']
+        resultColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
+      }
+    }
+
+    let resultOptions = []
+    for (let key of env.results.keys()){
+      resultOptions.push({value: DATA_REPORT + '_' + key, type: DATA_REPORT, label: key})
+    }
+
+    // Indicate the tab was updated if it has been.
+    let tabUpdated = this.state.tabUpdated
+    if (results && results != this.state.results && this.state.tabValue != this.state.RESULTS_TAB_INDEX){
+      tabUpdated.results = true
+    }
+    this.setState({resultKeys:resultKeys, results: results, resultColumns: formattedColumns,
+      activeResultOption: activeResultOption, resultOptions: resultOptions,
+      tabUpdated: tabUpdated})
+  }
+
 
   updatePlotInformation (env) {
     const plotKeys = env.plots.keys()
@@ -495,6 +549,9 @@ export class TidyBlocksApp extends React.Component {
     switch(newValue) {
       case this.state.DATA_TAB_INDEX:
         tabUpdated.data = false
+        break
+      case this.state.RESULTS_TAB_INDEX:
+        tabUpdated.results = false
         break
       case this.state.STATS_TAB_INDEX:
         tabUpdated.stats = false
@@ -588,6 +645,8 @@ export class TidyBlocksApp extends React.Component {
     const logMessageList = <ul className="tb-messages">{logMessages}</ul>
     const dataDropdown = <DataTabSelect options={this.state.dataOptions}
       onChange={this.changeData} value={this.state.activeDataOption}/>
+    const resultsDropdown = <DataTabSelect options={this.state.resultOptions}
+      onChange={this.changeResults} value={this.state.activeResultOption}/>
     const statsDropdown = <StatsTabSelect options={this.state.statsOptions}
       onChange={this.changeStats} value={this.state.activeStatsOption}/>
     const plotDropdown = <PlotTabSelect options={this.state.plotOptions}
@@ -611,7 +670,7 @@ export class TidyBlocksApp extends React.Component {
               <SaveSvgFormDialog ref={this.saveSvgDialog} data={this.getWorkspace().state.workspace}/>
             </>
           }
-          <MenuBar 
+          <MenuBar
             loadCsvClick={this.loadCsvClick}
             loadWorkspaceClick={this.loadWorkspaceClick}
             saveWorkspace={this.saveWorkspace}
@@ -651,6 +710,7 @@ export class TidyBlocksApp extends React.Component {
                     tabValue={this.state.tabValue}
                     handleTabChange={this.handleTabChange}
                     dataIndex={this.state.DATA_TAB_INDEX}
+                    resultIndex={this.state.RESULTS_TAB_INDEX}
                     statsIndex={this.state.STATS_TAB_INDEX}
                     plotIndex={this.state.PLOT_TAB_INDEX}
                     tabUpdated={this.state.tabUpdated}
@@ -662,6 +722,7 @@ export class TidyBlocksApp extends React.Component {
                   restorePanel={this.restorePanel}
                   maximizePanel={this.maximizePanel}
                   dataDropdown={dataDropdown}
+                  resultsDropdown={resultsDropdown}
                   statsDropdown={statsDropdown}
                   plotDropdown={plotDropdown}
                   plotOutputRef={this.plotOutputRef}
@@ -671,6 +732,9 @@ export class TidyBlocksApp extends React.Component {
                   data={this.state.data}
                   topRightPaneHeight={this.state.topRightPaneHeight}
                   sortRows={this.state.sortRows}
+                  resultColumns={this.state.resultColumns}
+                  resultGridRef={this.resultGridRef}
+                  results={this.state.results}
                   stats={this.state.stats}
                   statsColumns={this.state.statsColumns}
                   plotData={this.state.plotData}

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -372,8 +372,6 @@ export class TidyBlocksApp extends React.Component {
   runProgram () {
     TidyBlocksUI.runProgram()
     const env = TidyBlocksUI.env
-    console.log('env')
-    console.log(env)
     this.updateDataInformation(env)
     this.updateResultsInformation(env)
     this.updatePlotInformation(env)

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -24,9 +24,6 @@ import { DataTabSelect, StatsTabSelect, PlotTabSelect} from './select.jsx'
 import { TabSelectionBar, TabPanels } from './tabs.jsx'
 import { theme } from './theme.jsx'
 
-const DATA_USER = 'user'
-const DATA_REPORT = 'results'
-
 const createToolboxCategories = (props) => {
   const categories = parseWorkspaceXml(props.toolbox)
   const styles = props.settings.theme.categoryStyles
@@ -393,16 +390,14 @@ export class TidyBlocksApp extends React.Component {
       }
     }
     if (this.state.activeDataOption) {
-      if (this.state.activeDataOption.type == DATA_USER){
-        data = env.ui.userData.get(this.state.activeDataOption.label)['data']
-        dataColumns = env.ui.userData.get(this.state.activeDataOption.label)['columns']
-        dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
-      }
+      data = env.ui.userData.get(this.state.activeDataOption.label)['data']
+      dataColumns = env.ui.userData.get(this.state.activeDataOption.label)['columns']
+      dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
       activeDataOption = this.state.activeDataOption
     } else {
       let result = dataKeys.next()
       if (!result.done){
-        activeDataOption = {value: DATA_USER + '_' + result.value, type: DATA_USER, label: result.value}
+        activeDataOption = {value: result.value, label: result.value}
         data = env.ui.userData.get(activeDataOption.label)['data']
         dataColumns = env.ui.userData.get(activeDataOption.label)['columns']
         dataColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
@@ -410,7 +405,7 @@ export class TidyBlocksApp extends React.Component {
     }
     let dataOptions = []
     for (let key of env.ui.userData.keys()){
-      dataOptions.push({value: DATA_USER + '_' + key, type: DATA_USER, label: key})
+      dataOptions.push({value: key, label: key})
     }
 
     // Indicate the tab was updated if it has been.
@@ -446,7 +441,7 @@ export class TidyBlocksApp extends React.Component {
     } else {
       let result = resultKeys.next()
       if (!result.done){
-        activeResultOption = {value: DATA_USER + '_' + result.value, type: DATA_USER, label: result.value}
+        activeResultOption = {value: result.value, label: result.value}
         results = env.results.get(activeResultOption.label)['data']
         resultColumns = env.results.get(activeResultOption.label)['columns']
         resultColumns.forEach(c => formattedColumns.push({key: c, name: c, sortable: true, resizable: true}))
@@ -455,7 +450,7 @@ export class TidyBlocksApp extends React.Component {
 
     let resultOptions = []
     for (let key of env.results.keys()){
-      resultOptions.push({value: DATA_REPORT + '_' + key, type: DATA_REPORT, label: key})
+      resultOptions.push({value: key, label: key})
     }
 
     // Indicate the tab was updated if it has been.

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -180,6 +180,10 @@ export class TidyBlocksApp extends React.Component {
       this.setState({hideStatsTable: true}, () => {
         this.setState({hideStatsTable: false})
       })
+    } else if(this.state.results != prevState.results){
+      this.setState({hideResultTable: true}, () => {
+        this.setState({hideResultTable: false})
+      })
     }
   }
 
@@ -733,6 +737,7 @@ export class TidyBlocksApp extends React.Component {
                   plotData={this.state.plotData}
                   isDraggingPane={this.state.isDraggingPane}
                   hideDataTable={this.state.hideDataTable}
+                  hideResultTable={this.state.hideResultTable}
                   hideStatsTable={this.state.hideStatsTable}
                 />
               </div>

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -125,7 +125,7 @@ module.exports = {
   TABLE,
   HEAD: new MockTransform('head', (runner, df) => TABLE, [], false, true),
   MIDDLE: new MockTransform('middle', pass, [], true, true),
-  REPORT: new Transform.report('keyword'),
+  REPORT: new Transform.saveAs('keyword'),
   NO_OUTPUT: new MockTransform('no_output', pass, [], true, false),
   pass,
   TestInterface

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -123,10 +123,9 @@ module.exports = {
   ],
   COLORS: require('../data/colors'),
   TABLE,
-  HEAD: new MockTransform('head', (runner, df) => TABLE, [], false, true),
-  MIDDLE: new MockTransform('middle', pass, [], true, true),
+  HEAD: new MockTransform('head', (runner, df) => TABLE, [], false, false),
+  MIDDLE: new MockTransform('middle', pass, [], true, false),
   REPORT: new Transform.saveAs('keyword'),
-  NO_OUTPUT: new MockTransform('no_output', pass, [], true, false),
   pass,
   TestInterface
 }

--- a/test/test_codegen.js
+++ b/test/test_codegen.js
@@ -527,10 +527,10 @@ describe('combiner code generation', () => {
     done()
   })
 
-  it('generates code for report', (done) => {
-    const expected = [Transform.FAMILY, 'report', 'stuff']
+  it('generates code for saveAs', (done) => {
+    const expected = [Transform.FAMILY, 'saveAs', 'stuff']
     const w = fixture.workspace()
-    const block = w.newBlock('transform_report')
+    const block = w.newBlock('transform_saveAs')
     block.setFieldValue('stuff', 'NAME')
     const actual = getCode(block)
     assert.deepEqual(expected, actual, `Mis-match`)

--- a/test/test_gui.js
+++ b/test/test_gui.js
@@ -25,7 +25,7 @@ describe('creates the interface object', () => {
     const block = gui.workspace.newBlock('data_colors')
     block.hat = 'cap'
     gui.runProgram()
-    assert.deepEqual(gui.env.log, [['log', 'read colors']],
+    assert.deepEqual(gui.env.log, [['log', 'read colors'], ['log', 'report unnamed 1']],
                      `Program did not run as expected`)
     done()
   })
@@ -43,7 +43,7 @@ describe('creates the interface object', () => {
     assert.deepEqual(code, program,
                      `Did not generate correct code`)
     gui.runProgram()
-    const expected = [['warn', '1 stray stacks found'], ['log', 'read colors']]
+    const expected = [['warn', '1 stray stacks found'], ['log', 'read colors'], ['log', 'report unnamed 1']]
     assert.deepEqual(gui.env.log, expected,
                      `Did not get stray count report`)
     done()

--- a/test/test_pipeline.js
+++ b/test/test_pipeline.js
@@ -46,20 +46,15 @@ describe('executes pipelines', () => {
     done()
   })
 
-  it('refuses to execute a pipeline whose early transforms do not produce output', (done) => {
-    const pipeline = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT, fixture.REPORT)
-    assert.throws(() => pipeline.run(new Env(INTERFACE)),
-                  Error,
-                  `Should not execute pipeline whose middle transform does not produce output`)
-    done()
-  })
-
-  it('executes a single-transform pipeline without a report', (done) => {
+  it('executes a single-transform pipeline without a report and saves anonymous output', (done) => {
     const pipeline = new Pipeline(fixture.HEAD)
     const env = new Env(INTERFACE)
     pipeline.run(env)
     assert.equal(env.results.size, 1,
                  `Only the unnamed result we generate should be reported`)
+    console.log('RESULTS', env.results)
+    assert(env.results.has(`${Pipeline.UNNAMED_RESULT} 1`),
+           `Anonymous result does not have expected name`)
     done()
   })
 

--- a/test/test_pipeline.js
+++ b/test/test_pipeline.js
@@ -58,8 +58,8 @@ describe('executes pipelines', () => {
     const pipeline = new Pipeline(fixture.HEAD)
     const env = new Env(INTERFACE)
     pipeline.run(env)
-    assert.equal(env.results.size, 0,
-                 `No results should be registered`)
+    assert.equal(env.results.size, 1,
+                 `Only the unnamed result we generate should be reported`)
     done()
   })
 
@@ -67,8 +67,8 @@ describe('executes pipelines', () => {
     const pipeline = new Pipeline(fixture.HEAD, fixture.MIDDLE)
     const env = new Env(INTERFACE)
     pipeline.run(env)
-    assert.equal(env.results.size, 0,
-                 `No results should be registered`)
+    assert.equal(env.results.size, 1,
+                 `Only the unnamed result we generate should be reported`)
     done()
   })
 

--- a/test/test_program.js
+++ b/test/test_program.js
@@ -206,14 +206,14 @@ describe('executes program', () => {
     done()
   })
 
-  it('runs a single pipeline with no dependencies that does not notify', (done) => {
+  it('runs a single pipeline with no dependencies that only returns the unnamed report', (done) => {
     const program = new Program()
     const pipeline = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT)
     program.register(pipeline)
     const env = new Env(INTERFACE)
     program.run(env)
-    assert.equal(env.results.size, 0,
-                 `Nothing should be registered`)
+    assert.equal(env.results.size, 1,
+                 `Only the unnamed report should be registered`)
     done()
   })
 
@@ -257,15 +257,15 @@ describe('executes program', () => {
     program.run(env)
     assert(env.getData('keyword').equal(fixture.TABLE),
            `Missing or incorrect table`)
-    assert.deepEqual(env.log, [['log', 'head'], ['log', 'report keyword'], ['log', 'headRequire']],
+    assert.deepEqual(env.log, [['log', 'head'], ['log', 'report keyword'], ['log', 'headRequire'], ["log", "report unnamed 1"]],
                      `Expected to see report in log`)
     done()
   })
 
   it('handles a join correctly', (done) => {
     const program = new Program()
-    const reportAlpha = new Transform.report('alpha')
-    const reportBeta = new Transform.report('beta')
+    const reportAlpha = new Transform.saveAs('alpha')
+    const reportBeta = new Transform.saveAs('beta')
     const join = new Transform.join('alpha', 'left', 'beta', 'left')
 
     program.register(new Pipeline(fixture.HEAD, reportAlpha))

--- a/test/test_program.js
+++ b/test/test_program.js
@@ -208,12 +208,14 @@ describe('executes program', () => {
 
   it('runs a single pipeline with no dependencies that only returns the unnamed report', (done) => {
     const program = new Program()
-    const pipeline = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT)
+    const pipeline = new Pipeline(fixture.HEAD)
     program.register(pipeline)
     const env = new Env(INTERFACE)
     program.run(env)
     assert.equal(env.results.size, 1,
                  `Only the unnamed report should be registered`)
+    assert.equal(env.getNextUnnamedId(), 2,
+                 `Should have incremented the next ID counter`)
     done()
   })
 
@@ -231,14 +233,16 @@ describe('executes program', () => {
 
   it('runs two independent pipelines in some order', (done) => {
     const program = new Program()
-    const pipeQuiet = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT)
+    const pipeQuiet = new Pipeline(fixture.HEAD)
     program.register(pipeQuiet)
     const pipeReport = new Pipeline(fixture.HEAD, fixture.REPORT)
     program.register(pipeReport)
     const env = new Env(INTERFACE)
     program.run(env)
+    assert(env.getData('unnamed 1').equal(fixture.TABLE),
+           `Missing or incorrect unnamed table`)
     assert(env.getData('keyword').equal(fixture.TABLE),
-           `Missing or incorrect table`)
+           `Missing or incorrect named table`)
     done()
   })
 

--- a/test/test_program.js
+++ b/test/test_program.js
@@ -264,8 +264,8 @@ describe('executes program', () => {
 
   it('handles a join correctly', (done) => {
     const program = new Program()
-    const reportAlpha = new Transform.report('alpha')
-    const reportBeta = new Transform.report('beta')
+    const reportAlpha = new Transform.saveAs('alpha')
+    const reportBeta = new Transform.saveAs('beta')
     const join = new Transform.join('alpha', 'left', 'beta', 'left')
 
     program.register(new Pipeline(fixture.HEAD, reportAlpha))

--- a/test/test_program.js
+++ b/test/test_program.js
@@ -206,14 +206,14 @@ describe('executes program', () => {
     done()
   })
 
-  it('runs a single pipeline with no dependencies that does not notify', (done) => {
+  it('runs a single pipeline with no dependencies that only returns the unnamed report', (done) => {
     const program = new Program()
     const pipeline = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT)
     program.register(pipeline)
     const env = new Env(INTERFACE)
     program.run(env)
-    assert.equal(env.results.size, 0,
-                 `Nothing should be registered`)
+    assert.equal(env.results.size, 1,
+                 `Only the unnamed report should be registered`)
     done()
   })
 
@@ -257,7 +257,7 @@ describe('executes program', () => {
     program.run(env)
     assert(env.getData('keyword').equal(fixture.TABLE),
            `Missing or incorrect table`)
-    assert.deepEqual(env.log, [['log', 'head'], ['log', 'report keyword'], ['log', 'headRequire']],
+    assert.deepEqual(env.log, [['log', 'head'], ['log', 'report keyword'], ['log', 'headRequire'], ["log", "report unnamed 1"]],
                      `Expected to see report in log`)
     done()
   })

--- a/test/test_restore.js
+++ b/test/test_restore.js
@@ -36,7 +36,7 @@ describe('expression persistence', () => {
                   `Requires known kind of expression`)
     done()
   })
-  
+
   it('restores a row number', (done) => {
     const factory = new Restore()
     assert.deepEqual(factory.expr([Value.FAMILY, 'rownum']),
@@ -44,7 +44,7 @@ describe('expression persistence', () => {
                      `Row number`)
     done()
   })
-  
+
   it('restores a number', (done) => {
     const factory = new Restore()
     assert.deepEqual(factory.expr([Value.FAMILY, 'number', 123]),
@@ -250,8 +250,8 @@ describe('transform persistence', () => {
   it('restores report from JSON', (done) => {
     const label = 'result_name'
     const factory = new Restore()
-    assert.deepEqual(factory.transform([Transform.FAMILY, 'report', label]),
-                     new Transform.report(label),
+    assert.deepEqual(factory.transform([Transform.FAMILY, 'saveAs', label]),
+                     new Transform.saveAs(label),
                      `report`)
     done()
   })

--- a/test/test_transform.js
+++ b/test/test_transform.js
@@ -96,9 +96,9 @@ describe('build dataframe operations', () => {
     done()
   })
 
-  it('builds report transform', (done) => {
+  it('builds saveAs transform', (done) => {
     const env = new Env(INTERFACE)
-    const transform = new Transform.report('answer')
+    const transform = new Transform.saveAs('answer')
     const input = new DataFrame(fixture.NAMES)
     const result = transform.run(env, input)
     const expected = new DataFrame(fixture.NAMES)
@@ -463,9 +463,9 @@ describe('transform equality tests', () => {
     done()
   })
 
-  it('compares report', (done) => {
-    const report_a = new Transform.report('a')
-    const report_b = new Transform.report('b')
+  it('compares saveAs reports', (done) => {
+    const report_a = new Transform.saveAs('a')
+    const report_b = new Transform.saveAs('b')
     assert(report_a.equal(report_a),
            `Same should match`)
     assert(!report_a.equal(report_b),
@@ -531,7 +531,7 @@ describe('transform equality tests', () => {
     const u2 = new Transform.ungroup()
     assert(u1.equal(u2),
            `All ungroup transforms should be equal`)
-    const report = new Transform.report('name')
+    const report = new Transform.saveAs('name')
     assert(!report.equal(u1),
            `Different transforms should not equal`)
     done()


### PR DESCRIPTION
Consolidating changes to produce unnamed reports (based off #344).

1.  Moved utility function to format multiple columns names into `./blocks/helpers.js` for consistency's sake (puts `MESSAGE` tables at the top of all blocks files).
1.  Made title-casing consistent (`saveAs` everywhere instead of `saveas`, and `groupBy` instead of `groupby` to be consistent).
1.  Marked strings in Spanish, Arabic, and Korean that need to be re-translated.
1.  Since all transforms always produce output, get rid of the `output` constructor parameter.
    Instead, use a Boolean flag to indicate whether each type of transform records its results (saveAs, plot, stats) or not (everything else).
    -   Made constructors of stats transforms more uniform.
1.  Modify `Pipeline.run` so that it checks this flag rather than checking concrete transform classes. This will make future expansion less brittle.
1.  Move the counter for unnamed results into the `Env` class.
1.  Modify `Pipeline.run` to use the counter in the `Env` class. (This fixes a bug in tests: we were calling `pipeline.run(env)` when we needed to call `pipeline.run(env, counter)`.)
    -   Added comments to explain a little of what's going on.
1.  Got rid of the `NO_OUTPUT` fixture in testing, since all transforms now produce output.
1.  Removed a couple of tests that were no longer relevant, and added checks to some others to make sure anonymous results are saved under the correct name.