### PR TITLE
Fixing help URLs in blocks.

### DIFF
--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -128,7 +128,7 @@ const setup = (language) => {
       style: 'combine_block',
       hat: 'cap',
       tooltip: msg.get('glue.tooltip'),
-      helpUrl: './combine/#glue',
+      helpUrl: './guide/#glue',
       extensions: ['validate_LEFT_TABLE', 'validate_RIGHT_TABLE', 'validate_COLUMN']
     },
     // Join
@@ -165,7 +165,7 @@ const setup = (language) => {
       style: 'combine_block',
       hat: 'cap',
       tooltip: msg.get('join.tooltip'),
-      helpUrl: './combine/#join',
+      helpUrl: './guide/#join',
       extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
     }
   ])

--- a/blocks/data.js
+++ b/blocks/data.js
@@ -151,7 +151,7 @@ const setup = (language) => {
       style: 'data_block',
       hat: 'cap',
       tooltip: msg.get('colors.tooltip'),
-      helpUrl: './data/#colors'
+      helpUrl: './guide/#colors'
     },
     // Earthquakes
     {
@@ -161,7 +161,7 @@ const setup = (language) => {
       style: 'data_block',
       hat: 'cap',
       tooltip: msg.get('earthquakes.tooltip'),
-      helpUrl: './data/#earthquakes'
+      helpUrl: './guide/#earthquakes'
     },
     // Penguins
     {
@@ -171,7 +171,7 @@ const setup = (language) => {
       style: 'data_block',
       hat: 'cap',
       tooltip: msg.get('penguins.tooltip'),
-      helpUrl: './data/#penguins'
+      helpUrl: './guide/#penguins'
     },
     // Phish
     {
@@ -181,7 +181,7 @@ const setup = (language) => {
       style: 'data_block',
       hat: 'cap',
       tooltip: msg.get('phish.tooltip'),
-      helpUrl: './data/#phish'
+      helpUrl: './guide/#phish'
     },
     // Sequence
     {
@@ -202,7 +202,7 @@ const setup = (language) => {
       style: 'data_block',
       hat: 'cap',
       tooltip: msg.get('sequence.tooltip'),
-      helpUrl: './data/#sequence'
+      helpUrl: './guide/#sequence'
     },
     // User data
     {
@@ -217,7 +217,7 @@ const setup = (language) => {
       style: 'data_block',
       hat: 'cap',
       tooltip: msg.get('data_user.tooltip'),
-      helpUrl: './data/#user'
+      helpUrl: './guide/#user'
     }
   ])
 

--- a/blocks/op.js
+++ b/blocks/op.js
@@ -190,7 +190,7 @@ const setup = (language) => {
       output: 'Number',
       style: 'op_block',
       tooltip: msg.get('arithmetic.tooltip'),
-      helpUrl: './op/#arithmetic'
+      helpUrl: './guide/#arithmetic'
     },
 
     // Arithmetic negation
@@ -205,7 +205,7 @@ const setup = (language) => {
       output: 'Number',
       style: 'op_block',
       tooltip: msg.get('negate.tooltip'),
-      helpUrl: './op/#negate'
+      helpUrl: './guide/#negate'
     },
 
     // Absolute value
@@ -220,7 +220,7 @@ const setup = (language) => {
       output: 'Number',
       style: 'op_block',
       tooltip: msg.get('abs.tooltip'),
-      helpUrl: './op/#abs'
+      helpUrl: './guide/#abs'
     },
 
     // Comparisons
@@ -252,7 +252,7 @@ const setup = (language) => {
       output: 'Boolean',
       style: 'op_block',
       tooltip: msg.get('compare.tooltip'),
-      helpUrl: './op/#compare'
+      helpUrl: './guide/#compare'
     },
 
     // Binary logical operations
@@ -280,7 +280,7 @@ const setup = (language) => {
       output: 'Boolean',
       style: 'op_block',
       tooltip: msg.get('logical.tooltip'),
-      helpUrl: './op/#logical'
+      helpUrl: './guide/#logical'
     },
 
     // Logical negation
@@ -295,7 +295,7 @@ const setup = (language) => {
       output: 'Boolean',
       style: 'op_block',
       tooltip: msg.get('not.tooltip'),
-      helpUrl: './op/#not'
+      helpUrl: './guide/#not'
     },
 
     // Type checking
@@ -322,7 +322,7 @@ const setup = (language) => {
       output: 'Boolean',
       style: 'op_block',
       tooltip: msg.get('type.tooltip'),
-      helpUrl: './op/#type'
+      helpUrl: './guide/#type'
     },
 
     // Type conversion
@@ -348,7 +348,7 @@ const setup = (language) => {
       output: 'Number',
       style: 'op_block',
       tooltip: msg.get('convert.tooltip'),
-      helpUrl: './op/#convert'
+      helpUrl: './guide/#convert'
     },
 
     // Datetime conversions
@@ -377,7 +377,7 @@ const setup = (language) => {
       output: 'Number',
       style: 'op_block',
       tooltip: msg.get('datetime.tooltip'),
-      helpUrl: './op/#datetime'
+      helpUrl: './guide/#datetime'
     },
 
     // Conditional
@@ -401,7 +401,7 @@ const setup = (language) => {
       output: 'Boolean',
       style: 'op_block',
       tooltip: msg.get('conditional.tooltip'),
-      helpUrl: './op/#conditional'
+      helpUrl: './guide/#conditional'
     }
   ])
 

--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -166,7 +166,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'plot_block',
       tooltip: msg.get('plot_bar.tooltip'),
-      helpUrl: './plot/#bar',
+      helpUrl: './guide/#bar',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS']
     },
 
@@ -195,7 +195,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'plot_block',
       tooltip: msg.get('plot_box.tooltip'),
-      helpUrl: './plot/#box',
+      helpUrl: './guide/#box',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS']
     },
 
@@ -219,7 +219,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'plot_block',
       tooltip: msg.get('plot_dot.tooltip'),
-      helpUrl: './plot/#dot',
+      helpUrl: './guide/#dot',
       extensions: ['validate_NAME', 'validate_X_AXIS']
     },
 
@@ -248,7 +248,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'plot_block',
       tooltip: msg.get('plot_histogram.tooltip'),
-      helpUrl: './plot/#histogram',
+      helpUrl: './guide/#histogram',
       extensions: ['validate_NAME', 'validate_COLUMN']
     },
 
@@ -287,7 +287,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'plot_block',
       tooltip: msg.get('plot_scatter.tooltip'),
-      helpUrl: './plot/#scatter',
+      helpUrl: './guide/#scatter',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS', 'validate_COLOR']
     }
   ])

--- a/blocks/stats.js
+++ b/blocks/stats.js
@@ -138,7 +138,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'stats_blocks',
       tooltip: msg.get('stats_ttest_one.tooltip'),
-      helpUrl: './stats/#ttest_one'
+      helpUrl: './guide/#ttest_one'
     },
 
     // Two-sample two-sided t-test
@@ -168,7 +168,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'stats_blocks',
       tooltip: msg.get('stats_ttest_two.tooltip'),
-      helpUrl: './stats/#ttest_two'
+      helpUrl: './guide/#ttest_two'
     }
   ])
 

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -260,7 +260,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('create.tooltip'),
-      helpUrl: './transform/#create',
+      helpUrl: './guide/#create',
       extensions: ['validate_COLUMN']
     },
 
@@ -278,7 +278,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('drop.args0_tooltip'),
-      helpUrl: './transform/#drop',
+      helpUrl: './guide/#drop',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
 
@@ -295,7 +295,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('filter.tooltip'),
-      helpUrl: './transform/#filter'
+      helpUrl: './guide/#filter'
     },
 
     // Group by
@@ -312,7 +312,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('groupBy.tooltip'),
-      helpUrl: './transform/#groupBy',
+      helpUrl: './guide/#groupBy',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
 
@@ -329,7 +329,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('saveAs.tooltip'),
-      helpUrl: './transform/#saveAs',
+      helpUrl: './guide/#saveAs',
       extensions: ['validate_NAME']
     },
 
@@ -347,7 +347,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('select.tooltip'),
-      helpUrl: './transform/#select',
+      helpUrl: './guide/#select',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
 
@@ -372,7 +372,7 @@ const setup = (language) => {
       style: 'transform_block',
       extensions: ['validate_MULTIPLE_COLUMNS'],
       tooltip: msg.get('sort.tooltip'),
-      helpUrl: './transform/#sort'
+      helpUrl: './guide/#sort'
     },
 
     // Summarize
@@ -406,7 +406,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('summarize.tooltip'),
-      helpUrl: './transform/#summarize',
+      helpUrl: './guide/#summarize',
       extensions: ['validate_COLUMN']
     },
 
@@ -420,7 +420,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('ungroup.tooltip'),
-      helpUrl: './transform/#ungroup'
+      helpUrl: './guide/#ungroup'
     },
 
     // Unique
@@ -437,7 +437,7 @@ const setup = (language) => {
       nextStatement: null,
       style: 'transform_block',
       tooltip: msg.get('unique.tooltip'),
-      helpUrl: './transform/#unique',
+      helpUrl: './guide/#unique',
       extensions: ['validate_MULTIPLE_COLUMNS']
     }
   ])

--- a/blocks/value.js
+++ b/blocks/value.js
@@ -191,7 +191,7 @@ const setup = (language) => {
       args0: [],
       output: 'String',
       style: 'value_block',
-      helpUrl: './value/#absent',
+      helpUrl: './guide/#absent',
       tooltip: msg.get('absent.tooltip')
     },
 
@@ -206,7 +206,7 @@ const setup = (language) => {
       }],
       output: 'String',
       style: 'value_block',
-      helpUrl: './value/#column',
+      helpUrl: './guide/#column',
       tooltip: msg.get('column.tooltip'),
       extensions: ['validate_COLUMN']
     },
@@ -222,7 +222,7 @@ const setup = (language) => {
       }],
       output: 'DateTime',
       style: 'value_block',
-      helpUrl: './value/#datetime',
+      helpUrl: './guide/#datetime',
       tooltip: msg.get('datetime.tooltip'),
       extensions: ['validate_DATE']
     },
@@ -240,7 +240,7 @@ const setup = (language) => {
         ]
       }],
       output: 'Boolean',
-      helpUrl: './value/#logical',
+      helpUrl: './guide/#logical',
       style: 'value_block',
       tooltip: msg.get('logical.tooltip')
     },
@@ -255,7 +255,7 @@ const setup = (language) => {
         value: 0
       }],
       output: 'Number',
-      helpUrl: './value/#number',
+      helpUrl: './guide/#number',
       style: 'value_block',
       tooltip: msg.get('number.tooltip')
     },
@@ -271,7 +271,7 @@ const setup = (language) => {
       }],
       output: 'String',
       style: 'value_block',
-      helpUrl: './value/#text',
+      helpUrl: './guide/#text',
       tooltip: msg.get('text.tooltip')
     },
 
@@ -282,7 +282,7 @@ const setup = (language) => {
       args0: [],
       output: 'String',
       style: 'value_block',
-      helpUrl: './value/#rownum',
+      helpUrl: './guide/#rownum',
       tooltip: msg.get('rownum.tooltip')
     },
 
@@ -297,7 +297,7 @@ const setup = (language) => {
       }],
       output: 'Number',
       style: 'value_block',
-      helpUrl: './value/#exponential',
+      helpUrl: './guide/#exponential',
       tooltip: msg.get('exponential.tooltip'),
       extensions: ['validate_RATE']
     },
@@ -319,7 +319,7 @@ const setup = (language) => {
       ],
       output: 'Number',
       style: 'value_block',
-      helpUrl: './value/#normal',
+      helpUrl: './guide/#normal',
       tooltip: msg.get('normal.tooltip'),
       extensions: ['validate_STDDEV']
     },
@@ -341,7 +341,7 @@ const setup = (language) => {
       ],
       output: 'Number',
       style: 'value_block',
-      helpUrl: './value/#uniform',
+      helpUrl: './guide/#uniform',
       tooltip: msg.get('uniform.tooltip')
     }
   ])


### PR DESCRIPTION
All blocks were still pointing at individual pages, but the new website consolidates all help into a single guide page.