### PR TITLE
Adding numrows to protocol

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -6,5 +6,8 @@
       "corejs": 3,
       "useBuiltIns": "entry"
     }]
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/libs/dataframe.js
+++ b/libs/dataframe.js
@@ -82,9 +82,10 @@ class DataFrame {
                `illegal new name for column`)
     util.check(expr instanceof ExprBase,
                `new value expression is not an expression object`)
+    const numRows = this.data.length
     const newData = this.data.map((row, i) => {
       const newRow = {...row}
-      newRow[newName] = expr.run(row, i)
+      newRow[newName] = expr.run(row, i, numRows)
       return newRow
     })
     const newColumns = this._makeColumns(newData, this.columns,
@@ -113,7 +114,8 @@ class DataFrame {
   filter (expr) {
     util.check(expr instanceof ExprBase,
                `filter expression is not an expression object`)
-    const newData = this.data.filter((row, i) => expr.run(row, i))
+    const numRows = this.data.length
+    const newData = this.data.filter((row, i) => expr.run(row, i, numRows))
     const newColumns = this._makeColumns(newData, this.columns)
     return new DataFrame(newData, newColumns)
   }

--- a/libs/op.js
+++ b/libs/op.js
@@ -15,25 +15,16 @@ const FAMILY = '@op'
 // ----------------------------------------------------------------------
 
 /**
- * Base class for negations.
- */
-class OpNegationBase extends ExprUnary {
-  constructor (species, arg) {
-    super(FAMILY, species, arg)
-  }
-}
-
-/**
  * Arithmetic negation.
  */
-class OpNegate extends OpNegationBase {
+class OpNegate extends ExprUnary {
   /**
    * Constructor.
    * @param {expr} arg How to get the value.
    * @returns The negation.
    */
   constructor (arg) {
-    super('negate', arg)
+    super(FAMILY, 'negate', arg)
   }
 
   /**
@@ -42,8 +33,8 @@ class OpNegate extends OpNegationBase {
    * @param {number} i The row's index.
    * @return The negation of the value returned by the sub-expression.
    */
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     util.checkNumber(value,
                      `Require number for ${this.name}`)
     return (value === util.MISSING) ? util.MISSING : util.safeValue(-value)
@@ -69,8 +60,8 @@ class OpAbs extends ExprUnary {
    * @param {number} i The row's index.
    * @return The negation of the value returned by the sub-expression.
    */
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     util.checkNumber(value,
                      `Require number for ${this.name}`)
     return (value === util.MISSING) ? util.MISSING : util.safeValue(Math.abs(value))
@@ -80,14 +71,14 @@ class OpAbs extends ExprUnary {
 /**
  * Logical negation.
  */
-class OpNot extends OpNegationBase {
+class OpNot extends ExprUnary {
   /**
    * Constructor.
    * @param {expr} arg How to get the value.
    * @returns The negation.
    */
   constructor (arg) {
-    super('not', arg)
+    super(FAMILY, 'not', arg)
   }
 
   /**
@@ -96,8 +87,8 @@ class OpNot extends OpNegationBase {
    * @param {number} i The row's index.
    * @return The logical negation of the value returned by the sub-expression.
    */
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     return (value === util.MISSING) ? util.MISSING : !util.makeLogical(value)
   }
 }
@@ -124,8 +115,8 @@ class OpTypecheckBase extends ExprUnary {
    * @param {string} typeName What type to check for.
    * @returns True or false.
    */
-  typeCheck (row, i, typeName) {
-    const value = this.arg.run(row, i)
+  typeCheck (row, i, numRows, typeName) {
+    const value = this.arg.run(row, i, numRows)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -142,8 +133,8 @@ class OpIsLogical extends OpTypecheckBase {
     super('isLogical', arg)
   }
 
-  run (row, i) {
-    return this.typeCheck(row, i, 'boolean')
+  run (row, i, numRows) {
+    return this.typeCheck(row, i, numRows, 'boolean')
   }
 }
 
@@ -155,8 +146,8 @@ class OpIsDatetime extends OpTypecheckBase {
     super('isDatetime', arg)
   }
 
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     return (value === util.MISSING) ? util.MISSING : (value instanceof Date)
   }
 }
@@ -169,8 +160,8 @@ class OpIsMissing extends OpTypecheckBase {
     super('isMissing', arg)
   }
 
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     return value === util.MISSING
   }
 }
@@ -183,8 +174,8 @@ class OpIsNumber extends OpTypecheckBase {
     super('isNumber', arg)
   }
 
-  run (row, i) {
-    return this.typeCheck(row, i, 'number')
+  run (row, i, numRows) {
+    return this.typeCheck(row, i, numRows, 'number')
   }
 }
 
@@ -196,8 +187,8 @@ class OpIsText extends OpTypecheckBase {
     super('isText', arg)
   }
 
-  run (row, i) {
-    return this.typeCheck(row, i, 'string')
+  run (row, i, numRows) {
+    return this.typeCheck(row, i, numRows, 'string')
   }
 }
 
@@ -231,8 +222,8 @@ class OpToLogical extends OpConvertBase {
    * @param {number} i The row's index.
    * @return The sub-expression value as MISSING, true, or false.
    */
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     return (value === util.MISSING) ? util.MISSING : util.makeLogical(value)
   }
 }
@@ -251,8 +242,8 @@ class OpToDatetime extends OpConvertBase {
    * @param {number} i The row's index.
    * @return The sub-expression value as MISSING or a Date.
    */
-  run (row, i) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     return util.makeDate(value)
   }
 }
@@ -271,8 +262,8 @@ class OpToNumber extends OpConvertBase {
    * @param {number} i The row's index.
    * @return The sub-expression value as a number.
    */
-  run (row, i) {
-    let value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    let value = this.arg.run(row, i, numRows)
     return util.makeNumber(value)
   }
 }
@@ -291,8 +282,8 @@ class OpToText extends OpConvertBase {
    * @param {number} i The row's index.
    * @return The sub-expression value as text.
    */
-  run (row, i) {
-    let value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    let value = this.arg.run(row, i, numRows)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -314,25 +305,25 @@ class OpDatetimeBase extends ExprUnary {
    * @param {string} species The precise function name.
    * @param arg How to get a value.
    */
-  constructor (species, arg) {
+  constructor (species, arg, converter) {
     super(FAMILY, species, arg)
+    this.converter = converter
   }
 
   /**
    * Extract a date component.
    * @param {object} row The row to operate on.
    * @param {number} i The row index within the dataframe.
-   * @param func How to get the date component value.
    * @returns The date component's value.
    */
-  dateValue (row, i, func) {
-    const value = this.arg.run(row, i)
+  run (row, i, numRows) {
+    const value = this.arg.run(row, i, numRows)
     if (value === util.MISSING) {
       return util.MISSING
     }
     util.check(value instanceof Date,
                `Require date for ${this.species}`)
-    return func(value)
+    return this.converter(value)
   }
 }
 
@@ -340,12 +331,10 @@ class OpDatetimeBase extends ExprUnary {
  * Extract year from date.
  */
 class OpToYear extends OpDatetimeBase {
-  constructor (arg) {
-    super('toYear', arg)
-  }
+  static CONVERTER = d => d.getFullYear()
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getFullYear())
+  constructor (arg) {
+    super('toYear', arg, OpToYear.CONVERTER)
   }
 }
 
@@ -353,12 +342,10 @@ class OpToYear extends OpDatetimeBase {
  * Extract 1-based month from date.
  */
 class OpToMonth extends OpDatetimeBase {
-  constructor (arg) {
-    super('toMonth', arg)
-  }
+  static CONVERTER = d => d.getMonth() + 1
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getMonth() + 1)
+  constructor (arg) {
+    super('toMonth', arg, OpToMonth.CONVERTER)
   }
 }
 
@@ -366,12 +353,10 @@ class OpToMonth extends OpDatetimeBase {
  * Extract 1-based day of month from date.
  */
 class OpToDay extends OpDatetimeBase {
-  constructor (arg) {
-    super('toDay', arg)
-  }
+  static CONVERTER = d => d.getDate()
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getDate())
+  constructor (arg) {
+    super('toDay', arg, OpToDay.CONVERTER)
   }
 }
 
@@ -379,12 +364,10 @@ class OpToDay extends OpDatetimeBase {
  * Extract day of week from date.
  */
 class OpToWeekday extends OpDatetimeBase {
-  constructor (arg) {
-    super('toWeekday', arg)
-  }
+  static CONVERTER = d => d.getDay()
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getDay())
+  constructor (arg) {
+    super('toWeekday', arg, OpToWeekday.CONVERTER)
   }
 }
 
@@ -392,12 +375,10 @@ class OpToWeekday extends OpDatetimeBase {
  * Extract hour from date.
  */
 class OpToHours extends OpDatetimeBase {
-  constructor (arg) {
-    super('toHours', arg)
-  }
+  static CONVERTER = d => d.getHours()
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getHours())
+  constructor (arg) {
+    super('toHours', arg, OpToHours.CONVERTER)
   }
 }
 
@@ -405,12 +386,10 @@ class OpToHours extends OpDatetimeBase {
  * Extract minutes from date.
  */
 class OpToMinutes extends OpDatetimeBase {
-  constructor (arg) {
-    super('toMinutes', arg)
-  }
+  static CONVERTER = d => d.getMinutes()
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getMinutes())
+  constructor (arg) {
+    super('toMinutes', arg, OpToMinutes.CONVERTER)
   }
 }
 
@@ -418,12 +397,10 @@ class OpToMinutes extends OpDatetimeBase {
  * Extract seconds from date.
  */
 class OpToSeconds extends OpDatetimeBase {
-  constructor (arg) {
-    super('toSeconds', arg)
-  }
+  static CONVERTER = d => d.getSeconds()
 
-  run (row, i) {
-    return this.dateValue(row, i, d => d.getSeconds())
+  constructor (arg) {
+    super('toSeconds', arg, OpToSeconds.CONVERTER)
   }
 }
 
@@ -439,27 +416,27 @@ class OpArithmeticBase extends ExprBinary {
    * @param {expr} left How to get the left value.
    * @param {expr} right How to get the right value.
    */
-  constructor (species, left, right) {
+  constructor (species, left, right, operator) {
     super(FAMILY, species, left, right)
+    this.operator = operator
   }
 
   /**
    * Perform a binary arithmetic operation.
    * @param {object} row The row to operate on.
    * @param {number} i The row index within the dataframe.
-   * @param func How to calculate the result.
    * @returns The result.
    */
-  arithmetic (row, i, func) {
-    const left = this.left.run(row, i)
+  run (row, i, numRows) {
+    const left = this.left.run(row, i, numRows)
     util.checkNumber(left,
                      `Require number for ${this.species}`)
-    const right = this.right.run(row, i)
+    const right = this.right.run(row, i, numRows)
     util.checkNumber(right,
                      `Require number for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
-      : util.safeValue(func(left, right))
+      : util.safeValue(this.operator(left, right))
   }
 }
 
@@ -467,12 +444,10 @@ class OpArithmeticBase extends ExprBinary {
  * Addition.
  */
 class OpAdd extends OpArithmeticBase {
-  constructor (left, right) {
-    super('add', left, right)
-  }
+  static OPERATOR = (left, right) => left + right
 
-  run (row, i) {
-    return this.arithmetic(row, i, (left, right) => left + right)
+  constructor (left, right) {
+    super('add', left, right, OpAdd.OPERATOR)
   }
 }
 
@@ -480,12 +455,10 @@ class OpAdd extends OpArithmeticBase {
  * Division.
  */
 class OpDivide extends OpArithmeticBase {
-  constructor (left, right) {
-    super('divide', left, right)
-  }
+  static OPERATOR = (left, right) => left / right
 
-  run (row, i) {
-    return this.arithmetic(row, i, (left, right) => left / right)
+  constructor (left, right) {
+    super('divide', left, right, OpDivide.OPERATOR)
   }
 }
 
@@ -493,12 +466,10 @@ class OpDivide extends OpArithmeticBase {
  * Multiplication.
  */
 class OpMultiply extends OpArithmeticBase {
-  constructor (left, right) {
-    super('multiply', left, right)
-  }
+  static OPERATOR = (left, right) => left * right
 
-  run (row, i) {
-    return this.arithmetic(row, i, (left, right) => left * right)
+  constructor (left, right) {
+    super('multiply', left, right, OpMultiply.OPERATOR)
   }
 }
 
@@ -506,12 +477,10 @@ class OpMultiply extends OpArithmeticBase {
  * Exponentiation.
  */
 class OpPower extends OpArithmeticBase {
-  constructor (left, right) {
-    super('power', left, right)
-  }
+  static OPERATOR = (left, right) => left ** right
 
-  run (row, i) {
-    return this.arithmetic(row, i, (left, right) => left ** right)
+  constructor (left, right) {
+    super('power', left, right, OpPower.OPERATOR)
   }
 }
 
@@ -519,12 +488,10 @@ class OpPower extends OpArithmeticBase {
  * Remainder.
  */
 class OpRemainder extends OpArithmeticBase {
-  constructor (left, right) {
-    super('remainder', left, right)
-  }
+  static OPERATOR = (left, right) => left % right
 
-  run (row, i) {
-    return this.arithmetic(row, i, (left, right) => left % right)
+  constructor (left, right) {
+    super('remainder', left, right, OpRemainder.OPERATOR)
   }
 }
 
@@ -532,12 +499,10 @@ class OpRemainder extends OpArithmeticBase {
  * Subtraction.
  */
 class OpSubtract extends OpArithmeticBase {
-  constructor (left, right) {
-    super('subtract', left, right)
-  }
+  static OPERATOR = (left, right) => left - right
 
-  run (row, i) {
-    return this.arithmetic(row, i, (left, right) => left - right)
+  constructor (left, right) {
+    super('subtract', left, right, OpSubtract.OPERATOR)
   }
 }
 
@@ -553,25 +518,25 @@ class OpCompareBase extends ExprBinary {
    * @param {expr} left How to get the left value.
    * @param {expr} right How to get the right value.
    */
-  constructor (species, left, right) {
+  constructor (species, left, right, operator) {
     super(FAMILY, species, left, right)
+    this.operator = operator
   }
 
   /**
    * Perform a binary comparison operation.
    * @param {object} row The row to operate on.
    * @param {number} i The row index within the dataframe.
-   * @param func How to calculate the result.
    * @returns The result.
    */
-  comparison (row, i, func) {
-    const left = this.left.run(row, i)
-    const right = this.right.run(row, i)
+  run (row, i, numRows) {
+    const left = this.left.run(row, i, numRows)
+    const right = this.right.run(row, i, numRows)
     util.checkTypeEqual(left, right,
                         `Require equal types for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
-      : func(left, right)
+      : this.operator(left, right)
   }
 }
 
@@ -579,12 +544,10 @@ class OpCompareBase extends ExprBinary {
  * Equality.
  */
 class OpEqual extends OpCompareBase {
-  constructor (left, right) {
-    super('equal', left, right)
-  }
+  static OPERATOR = (left, right) => util.equal(left, right)
 
-  run (row, i) {
-    return this.comparison(row, i, (left, right) => util.equal(left, right))
+  constructor (left, right) {
+    super('equal', left, right, OpEqual.OPERATOR)
   }
 }
 
@@ -592,12 +555,10 @@ class OpEqual extends OpCompareBase {
  * Strictly greater than.
  */
 class OpGreater extends OpCompareBase {
-  constructor (left, right) {
-    super('greater', left, right)
-  }
+  static OPERATOR = (left, right) => (left > right)
 
-  run (row, i) {
-    return this.comparison(row, i, (left, right) => (left > right))
+  constructor (left, right) {
+    super('greater', left, right, OpGreater.OPERATOR)
   }
 }
 
@@ -605,12 +566,10 @@ class OpGreater extends OpCompareBase {
  * Greater than or equal.
  */
 class OpGreaterEqual extends OpCompareBase {
-  constructor (left, right) {
-    super('greaterEqual', left, right)
-  }
+  static OPERATOR = (left, right) => (left >= right)
 
-  run (row, i) {
-    return this.comparison(row, i, (left, right) => (left >= right))
+  constructor (left, right) {
+    super('greaterEqual', left, right, OpGreaterEqual.OPERATOR)
   }
 }
 
@@ -618,12 +577,10 @@ class OpGreaterEqual extends OpCompareBase {
  * Strictly less than.
  */
 class OpLess extends OpCompareBase {
-  constructor (left, right) {
-    super('less', left, right)
-  }
+  static OPERATOR = (left, right) => (left < right)
 
-  run (row, i) {
-    return this.comparison(row, i, (left, right) => (left < right))
+  constructor (left, right) {
+    super('less', left, right, OpLess.OPERATOR)
   }
 }
 
@@ -631,12 +588,10 @@ class OpLess extends OpCompareBase {
  * Less than or equal.
  */
 class OpLessEqual extends OpCompareBase {
-  constructor (left, right) {
-    super('lessEqual', left, right)
-  }
+  static OPERATOR = (left, right) => (left <= right)
 
-  run (row, i) {
-    return this.comparison(row, i, (left, right) => (left <= right))
+  constructor (left, right) {
+    super('lessEqual', left, right, OpLessEqual.OPERATOR)
   }
 }
 
@@ -644,12 +599,10 @@ class OpLessEqual extends OpCompareBase {
  * Inequality.
  */
 class OpNotEqual extends OpCompareBase {
-  constructor (left, right) {
-    super('notEqual', left, right)
-  }
+  static OPERATOR = (left, right) => (!util.equal(left, right))
 
-  run (row, i) {
-    return this.comparison(row, i, (left, right) => (!util.equal(left, right)))
+  constructor (left, right) {
+    super('notEqual', left, right, OpNotEqual.OPERATOR)
   }
 }
 
@@ -685,12 +638,12 @@ class OpAnd extends OpLogicalBase {
    * @returns The left value if it is not truthy, otherwise the right value. The
    * right expression is only evaluated if necessary.
    */
-  run (row, i) {
-    const left = this.left.run(row, i)
+  run (row, i, numRows) {
+    const left = this.left.run(row, i, numRows)
     if (!left) {
       return left
     }
-    return this.right.run(row, i)
+    return this.right.run(row, i, numRows)
   }
 }
 
@@ -709,12 +662,12 @@ class OpOr extends OpLogicalBase {
    * @returns The left value if it is truthy, otherwise the right value. The
    * right expression is only evaluated if necessary.
    */
-  run (row, i) {
-    const left = this.left.run(row, i)
+  run (row, i, numRows) {
+    const left = this.left.run(row, i, numRows)
     if (left) {
       return left
     }
-    return this.right.run(row, i)
+    return this.right.run(row, i, numRows)
   }
 }
 
@@ -741,11 +694,11 @@ class OpIfElse extends ExprTernary {
    * @returns The left value if the condition is truthy, otherwise the right
    * value. The left and right expressions are only evaluated if necessary.
    */
-  run (row, i) {
-    const cond = this.left.run(row, i)
+  run (row, i, numRows) {
+    const cond = this.left.run(row, i, numRows)
     return (cond === util.MISSING)
       ? util.MISSING
-      : (cond ? this.middle.run(row, i) : this.right.run(row, i))
+      : (cond ? this.middle.run(row, i, numRows) : this.right.run(row, i, numRows))
   }
 }
 

--- a/libs/value.js
+++ b/libs/value.js
@@ -28,7 +28,7 @@ class ValueAbsent extends ExprBase {
     return other instanceof ValueAbsent
   }
 
-  run (row, i) {
+  run (row, i, numRows) {
     util.fail('Missing expression')
   }
 }
@@ -48,7 +48,7 @@ class ValueRowNum extends ExprBase {
     return other instanceof ValueRowNum
   }
 
-  run (row, i) {
+  run (row, i, numRows) {
     return i
   }
 }
@@ -75,7 +75,7 @@ class ValueColumn extends ExprValue {
    * @param i The row number.
    * @returns The value (of any type).
    */
-  run (row, i) {
+  run (row, i, numRows) {
     util.check(typeof row === 'object',
                `Row must be object`)
     util.check(this.value in row,
@@ -105,7 +105,7 @@ class ValueDatetime extends ExprValue {
    * @param i The row number.
    * @returns The constant datetime value.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.value
   }
 }
@@ -130,7 +130,7 @@ class ValueLogical extends ExprValue {
    * @param i The row number.
    * @returns The constant logical value.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.value
   }
 }
@@ -155,7 +155,7 @@ class ValueNumber extends ExprValue {
    * @param i The row number.
    * @returns The constant numeric value.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.value
   }
 }
@@ -180,7 +180,7 @@ class ValueText extends ExprValue {
    * @param i The row number.
    * @returns The constant text value.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.value
   }
 }
@@ -206,7 +206,7 @@ class ValueExponential extends ExprValue {
    * @param i The row number.
    * @returns A sample from the distribution.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.generator()
   }
 }
@@ -248,7 +248,7 @@ class ValueNormal extends ExprBase {
    * @param i The row number.
    * @returns A sample from the distribution.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.generator()
   }
 }
@@ -292,7 +292,7 @@ class ValueUniform extends ExprBase {
    * @param i The row number.
    * @returns A sample from the distribution.
    */
-  run (row, i) {
+  run (row, i, numRows) {
     return this.generator()
   }
 }

--- a/test/test_op.js
+++ b/test/test_op.js
@@ -23,7 +23,8 @@ describe('arithmetic operations', () => {
   it('adds', (done) => {
     const expected = [4, 3, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.add(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for add`)
     done()
@@ -32,7 +33,8 @@ describe('arithmetic operations', () => {
   it('divides', (done) => {
     const expected = [1.0, -2.5, util.MISSING, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.divide(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for divide`)
     done()
@@ -41,7 +43,8 @@ describe('arithmetic operations', () => {
   it('exponentiates', (done) => {
     const expected = [4, 0.04, 1, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.power(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for power`)
     done()
@@ -50,7 +53,8 @@ describe('arithmetic operations', () => {
   it('multiplies', (done) => {
     const expected = [4, -10, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.multiply(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for multiply`)
     done()
@@ -59,7 +63,8 @@ describe('arithmetic operations', () => {
   it('negates', (done) => {
     const expected = [-2, 2, 0, -3, util.MISSING, util.MISSING]
     const op = new Op.negate(getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for negate`)
     done()
@@ -68,7 +73,8 @@ describe('arithmetic operations', () => {
   it('absolute value', (done) => {
     const expected = [2, 2, 0, 3, util.MISSING, util.MISSING]
     const op = new Op.abs(getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for absolute value`)
     done()
@@ -77,7 +83,8 @@ describe('arithmetic operations', () => {
   it('remainders', (done) => {
     const expected = [0, 1, util.MISSING, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.remainder(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for power`)
     done()
@@ -86,7 +93,8 @@ describe('arithmetic operations', () => {
   it('subtracts', (done) => {
     const expected = [0, 7, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.subtract(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for subtract`)
     done()
@@ -97,7 +105,8 @@ describe('logical operations', () => {
   it('ands', (done) => {
     const expected = [true, false, false, false, util.MISSING, false, util.MISSING]
     const op = new Op.and(getLeft, getRight)
-    const actual = fixture.BOOL.map((row, i) => op.run(row, i))
+    const numRows = fixture.BOOL.length
+    const actual = fixture.BOOL.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for and`)
     done()
@@ -106,7 +115,8 @@ describe('logical operations', () => {
   it('nots', (done) => {
     const expected = [false, false, true, true, util.MISSING, true, util.MISSING]
     const op = new Op.not(getLeft)
-    const actual = fixture.BOOL.map((row, i) => op.run(row, i))
+    const numRows = fixture.BOOL.length
+    const actual = fixture.BOOL.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not`)
     done()
@@ -115,7 +125,8 @@ describe('logical operations', () => {
   it('ors', (done) => {
     const expected = [true, true, true, false, false, util.MISSING, util.MISSING]
     const op = new Op.or(getLeft, getRight)
-    const actual = fixture.BOOL.map((row, i) => op.run(row, i))
+    const numRows = fixture.BOOL.length
+    const actual = fixture.BOOL.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for or`)
     done()
@@ -126,7 +137,8 @@ describe('comparison on numbers', () => {
   it('greater numbers', (done) => {
     const expected = [false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greater(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater numbers`)
     done()
@@ -135,7 +147,8 @@ describe('comparison on numbers', () => {
   it('greater equals numbers', (done) => {
     const expected = [true, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greaterEqual(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater equal numbers`)
     done()
@@ -144,7 +157,8 @@ describe('comparison on numbers', () => {
   it('equals numbers', (done) => {
     const expected = [true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.equal(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for equal numbers`)
     done()
@@ -153,7 +167,8 @@ describe('comparison on numbers', () => {
   it('not equals numbers', (done) => {
     const expected = [false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.notEqual(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not equal numbers`)
     done()
@@ -162,7 +177,8 @@ describe('comparison on numbers', () => {
   it('less equals numbers', (done) => {
     const expected = [true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.lessEqual(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less equal numbers`)
     done()
@@ -171,7 +187,8 @@ describe('comparison on numbers', () => {
   it('less numbers', (done) => {
     const expected = [false, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.less(getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less numbers`)
     done()
@@ -182,7 +199,8 @@ describe('comparison on strings', () => {
   it('greater strings', (done) => {
     const expected = [false, false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greater(getLeft, getRight)
-    const actual = fixture.STRING.map((row, i) => op.run(row, i))
+    const numRows = fixture.STRING.length
+    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater strings`)
     done()
@@ -191,7 +209,8 @@ describe('comparison on strings', () => {
   it('greater equals strings', (done) => {
     const expected = [true, false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greaterEqual(getLeft, getRight)
-    const actual = fixture.STRING.map((row, i) => op.run(row, i))
+    const numRows = fixture.STRING.length
+    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater equal strings`)
     done()
@@ -200,7 +219,8 @@ describe('comparison on strings', () => {
   it('equals strings', (done) => {
     const expected = [true, false, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.equal(getLeft, getRight)
-    const actual = fixture.STRING.map((row, i) => op.run(row, i))
+    const numRows = fixture.STRING.length
+    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for equal strings`)
     done()
@@ -209,7 +229,8 @@ describe('comparison on strings', () => {
   it('not equals strings', (done) => {
     const expected = [false, true, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.notEqual(getLeft, getRight)
-    const actual = fixture.STRING.map((row, i) => op.run(row, i))
+    const numRows = fixture.STRING.length
+    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not equal strings`)
     done()
@@ -218,7 +239,8 @@ describe('comparison on strings', () => {
   it('less equals strings', (done) => {
     const expected = [true, true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.lessEqual(getLeft, getRight)
-    const actual = fixture.STRING.map((row, i) => op.run(row, i))
+    const numRows = fixture.STRING.length
+    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less equal strings`)
     done()
@@ -227,7 +249,8 @@ describe('comparison on strings', () => {
   it('less strings', (done) => {
     const expected = [false, true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.less(getLeft, getRight)
-    const actual = fixture.STRING.map((row, i) => op.run(row, i))
+    const numRows = fixture.STRING.length
+    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less strings`)
     done()
@@ -239,7 +262,8 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(4000))
     const op = new Op.greater(test, getDate)
     const expected = [true, true, true]
-    const actual = threeDates.map((row, i) => op.run(row, i))
+    const numRows = threeDates.length
+    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for greater dates`)
     done()
@@ -249,7 +273,8 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.greaterEqual(test, getDate)
     const expected = [true, true, false]
-    const actual = threeDates.map((row, i) => op.run(row, i))
+    const numRows = threeDates.length
+    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for greater equal dates`)
     done()
@@ -259,7 +284,8 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.equal(test, getDate)
     const expected = [false, true, false]
-    const actual = threeDates.map((row, i) => op.run(row, i))
+    const numRows = threeDates.length
+    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for equal dates`)
     done()
@@ -269,7 +295,8 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.notEqual(test, getDate)
     const expected = [true, false, true]
-    const actual = threeDates.map((row, i) => op.run(row, i))
+    const numRows = threeDates.length
+    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for not equal dates`)
     done()
@@ -279,7 +306,8 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.lessEqual(test, getDate)
     const expected = [false, true, true]
-    const actual = threeDates.map((row, i) => op.run(row, i))
+    const numRows = threeDates.length
+    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for less equal dates`)
     done()
@@ -289,7 +317,8 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(1))
     const op = new Op.less(test, getDate)
     const expected = [false, true, true]
-    const actual = threeDates.map((row, i) => op.run(row, i))
+    const numRows = threeDates.length
+    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for less dates`)
     done()
@@ -300,7 +329,8 @@ describe('conditional', () => {
   it('pulls values conditionally', (done) => {
     const expected = [2, 5, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.ifElse(getRight, getLeft, getRight)
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i))
+    const numRows = fixture.NUMBER.length
+    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for conditional`)
     done()
@@ -323,8 +353,9 @@ describe('type checks', () => {
       [new Op.isDatetime(getStr), 'datetime', 'str'],
       [new Op.isNumber(getStr), 'num', 'str']
     ]
+    const numRows = fixture.MIXED.length
     for (const [check, tested, actual] of allChecks) {
-      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i)),
+      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i, numRows)),
                        [false, util.MISSING],
                        `Should not think ${actual} is ${tested}`)
     }
@@ -338,8 +369,9 @@ describe('type checks', () => {
       [new Op.isNumber(getNum), 'num'],
       [new Op.isText(getStr), 'text']
     ]
+    const numRows = fixture.MIXED.length
     for (const [check, name] of allChecks) {
-      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i)),
+      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i, numRows)),
                        [true, util.MISSING],
                        `Incorrect result(s) for ${name}`)
     }
@@ -353,9 +385,10 @@ describe('type checks', () => {
       [getNum, 'num'],
       [getStr, 'text']
     ]
+    const numRows = fixture.MIXED.length
     for (const [get, name] of allChecks) {
       const check = new Op.isMissing(get)
-      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i)),
+      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i, numRows)),
                        [false, true],
                        `Incorrect result(s) for ${name}`)
     }
@@ -390,7 +423,7 @@ describe('type conversions', () => {
     ]
     for (const [value, convert, expected] of checks) {
       const op = new convert(value)
-      const actual = op.run({}, 0)
+      const actual = op.run({}, 0, 1)
       assert.equal(actual, expected,
                    `Wrong result for ${value} and ${convert}: expected ${expected}, got ${actual}`)
     }
@@ -402,7 +435,7 @@ describe('type conversions', () => {
                     new Value.text('abc')]
     for (const input of checks) {
       const op = new Op.toDatetime(input)
-      assert.throws(() => op.run({}, 0),
+      assert.throws(() => op.run({}, 0, 1),
                     Error,
                     `Should not be able to convert "${input}"`)
     }
@@ -416,14 +449,14 @@ describe('type conversions', () => {
     ]
     for (const [expr, expected] of checks) {
       const op = new Op.toDatetime(expr)
-      const actual = op.run({}, 0)
+      const actual = op.run({}, 0, 1)
       assert(actual instanceof Date,
              `Wrong result type for ${expected}`)
       assert.equal(actual.getTime(), expected.getTime(),
                    `Wrong result for ${expected}`)
     }
     const op = new Op.toDatetime(new Value.number(util.MISSING))
-    const actual = op.run({}, 0)
+    const actual = op.run({}, 0, 1)
     assert.equal(actual, util.MISSING,
                  `Should have MISSING`)
     done()
@@ -434,19 +467,19 @@ describe('extract values from datetimes', () => {
   it('extracts components of datetimes', (done) => {
     // Zero-based month in constructor *sigh*.
     const value = new Value.datetime(new Date(1983, 11, 2, 7, 55, 19, 0))
-    assert.equal((new Op.toYear(value)).run({}, 0), 1983,
+    assert.equal((new Op.toYear(value)).run({}, 0, 1), 1983,
                  `Wrong year`)
-    assert.equal((new Op.toMonth(value)).run({}, 0), 12,
+    assert.equal((new Op.toMonth(value)).run({}, 0, 1), 12,
                  `Wrong month`)
-    assert.equal((new Op.toDay(value)).run({}, 0), 2,
+    assert.equal((new Op.toDay(value)).run({}, 0, 1), 2,
                  `Wrong day`)
-    assert.equal((new Op.toWeekday(value)).run({}, 0), 5,
+    assert.equal((new Op.toWeekday(value)).run({}, 0, 1), 5,
                  `Wrong weekday`)
-    assert.equal((new Op.toHours(value)).run({}, 0), 7,
+    assert.equal((new Op.toHours(value)).run({}, 0, 1), 7,
                  `Wrong hours`)
-    assert.equal((new Op.toMinutes(value)).run({}, 0), 55,
+    assert.equal((new Op.toMinutes(value)).run({}, 0, 1), 55,
                  `Wrong minutes`)
-    assert.equal((new Op.toSeconds(value)).run({}, 0), 19,
+    assert.equal((new Op.toSeconds(value)).run({}, 0, 1), 19,
                  `Wrong seconds`)
     done()
   })
@@ -464,7 +497,7 @@ describe('extract values from datetimes', () => {
     const value = new Value.datetime(util.MISSING)
     for (const [name, conv] of converters) {
       const op = new conv(value)
-      const result = op.run({}, 0)
+      const result = op.run({}, 0, 1)
       assert.equal(result, util.MISSING,
                    `Wrong result for ${name}`)
     }

--- a/test/test_restore.js
+++ b/test/test_restore.js
@@ -109,8 +109,17 @@ describe('expression persistence', () => {
     for (const [name, func] of allChecks) {
       const factory = new Restore()
       const json = [Op.FAMILY, name, childJSON, childJSON]
-      assert.deepEqual(factory.expr(json),
-                       new func(childObj, childObj),
+      console.log(`JSON ${JSON.stringify(json, null, 2)}`)
+      const actual = factory.expr(json)
+      console.log(`ACTUAL ${JSON.stringify(actual, null, 2)}`)
+      const expected = new func(childObj, childObj)
+      console.log(`EXPECTED ${JSON.stringify(expected, null, 2)}`)
+      assert.equal(actual.family, expected.family)
+      assert.equal(actual.kind, expected.kind)
+      assert.deepEqual(actual.left, expected.left)
+      assert.deepEqual(actual.right, expected.right)
+      assert.deepEqual(Object.keys(actual), Object.keys(expected))
+      assert.deepEqual(actual, expected,
                        `Failed to restore binary "${name}"`)
     }
     done()


### PR DESCRIPTION
Some new operators (like `shift`) will require the `run` method of expressions to know how many rows there are, so:

1.  Add that to the `run` protocol and update tests.
2.  Factor out common code in arithmetic and datetime operations.
3.  Modify Babel configuration to allow `static` class members to support the above.