### PR TITLE
Changing the iteration protocol.

### DIFF
--- a/libs/dataframe.js
+++ b/libs/dataframe.js
@@ -83,9 +83,9 @@ class DataFrame {
     util.check(expr instanceof ExprBase,
                `new value expression is not an expression object`)
     const numRows = this.data.length
-    const newData = this.data.map((row, i) => {
+    const newData = this.data.map((row, i, d) => {
       const newRow = {...row}
-      newRow[newName] = expr.run(this.data, i)
+      newRow[newName] = expr.run(row, i, d)
       return newRow
     })
     const newColumns = this._makeColumns(newData, this.columns,
@@ -115,7 +115,7 @@ class DataFrame {
     util.check(expr instanceof ExprBase,
                `filter expression is not an expression object`)
     const numRows = this.data.length
-    const newData = this.data.filter((row, i) => expr.run(this.data, i))
+    const newData = this.data.filter((row, i, d) => expr.run(row, i, d))
     const newColumns = this._makeColumns(newData, this.columns)
     return new DataFrame(newData, newColumns)
   }

--- a/libs/dataframe.js
+++ b/libs/dataframe.js
@@ -85,7 +85,7 @@ class DataFrame {
     const numRows = this.data.length
     const newData = this.data.map((row, i) => {
       const newRow = {...row}
-      newRow[newName] = expr.run(row, i, numRows)
+      newRow[newName] = expr.run(this.data, i)
       return newRow
     })
     const newColumns = this._makeColumns(newData, this.columns,
@@ -115,7 +115,7 @@ class DataFrame {
     util.check(expr instanceof ExprBase,
                `filter expression is not an expression object`)
     const numRows = this.data.length
-    const newData = this.data.filter((row, i) => expr.run(row, i, numRows))
+    const newData = this.data.filter((row, i) => expr.run(this.data, i))
     const newColumns = this._makeColumns(newData, this.columns)
     return new DataFrame(newData, newColumns)
   }

--- a/libs/expr.js
+++ b/libs/expr.js
@@ -4,7 +4,7 @@ const util = require('./util')
 
 /**
  * Represent an expression as an object. Derived classes must implement
- * `equal(other)` and `run(row, i)`.
+ * `equal(other)` and `run(row, i, data)`.
  */
 class ExprBase {
   /**

--- a/libs/op.js
+++ b/libs/op.js
@@ -2,6 +2,7 @@
 
 const util = require('./util')
 const {
+  ExprBase,
   ExprUnary,
   ExprBinary,
   ExprTernary
@@ -27,14 +28,8 @@ class OpNegate extends ExprUnary {
     super(FAMILY, 'negate', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The negation of the value returned by the sub-expression.
-   */
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     util.checkNumber(value,
                      `Require number for ${this.name}`)
     return (value === util.MISSING) ? util.MISSING : util.safeValue(-value)
@@ -54,14 +49,8 @@ class OpAbs extends ExprUnary {
     super(FAMILY, 'abs', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The negation of the value returned by the sub-expression.
-   */
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     util.checkNumber(value,
                      `Require number for ${this.name}`)
     return (value === util.MISSING) ? util.MISSING : util.safeValue(Math.abs(value))
@@ -81,14 +70,8 @@ class OpNot extends ExprUnary {
     super(FAMILY, 'not', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The logical negation of the value returned by the sub-expression.
-   */
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     return (value === util.MISSING) ? util.MISSING : !util.makeLogical(value)
   }
 }
@@ -110,13 +93,9 @@ class OpTypecheckBase extends ExprUnary {
 
   /**
    * Check the type of a value.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @param {string} typeName What type to check for.
-   * @returns True or false.
    */
-  typeCheck (row, i, numRows, typeName) {
-    const value = this.arg.run(row, i, numRows)
+  typeCheck (data, i, typeName) {
+    const value = this.arg.run(data, i)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -133,8 +112,8 @@ class OpIsLogical extends OpTypecheckBase {
     super('isLogical', arg)
   }
 
-  run (row, i, numRows) {
-    return this.typeCheck(row, i, numRows, 'boolean')
+  run (data, i) {
+    return this.typeCheck(data, i, 'boolean')
   }
 }
 
@@ -146,8 +125,8 @@ class OpIsDatetime extends OpTypecheckBase {
     super('isDatetime', arg)
   }
 
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     return (value === util.MISSING) ? util.MISSING : (value instanceof Date)
   }
 }
@@ -160,8 +139,8 @@ class OpIsMissing extends OpTypecheckBase {
     super('isMissing', arg)
   }
 
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     return value === util.MISSING
   }
 }
@@ -174,8 +153,8 @@ class OpIsNumber extends OpTypecheckBase {
     super('isNumber', arg)
   }
 
-  run (row, i, numRows) {
-    return this.typeCheck(row, i, numRows, 'number')
+  run (data, i) {
+    return this.typeCheck(data, i, 'number')
   }
 }
 
@@ -187,8 +166,8 @@ class OpIsText extends OpTypecheckBase {
     super('isText', arg)
   }
 
-  run (row, i, numRows) {
-    return this.typeCheck(row, i, numRows, 'string')
+  run (data, i) {
+    return this.typeCheck(data, i, 'string')
   }
 }
 
@@ -216,14 +195,8 @@ class OpToLogical extends OpConvertBase {
     super('toLogical', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The sub-expression value as MISSING, true, or false.
-   */
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     return (value === util.MISSING) ? util.MISSING : util.makeLogical(value)
   }
 }
@@ -236,14 +209,8 @@ class OpToDatetime extends OpConvertBase {
     super('toDatetime', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The sub-expression value as MISSING or a Date.
-   */
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     return util.makeDate(value)
   }
 }
@@ -256,14 +223,8 @@ class OpToNumber extends OpConvertBase {
     super('toNumber', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The sub-expression value as a number.
-   */
-  run (row, i, numRows) {
-    let value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    let value = this.arg.run(data, i)
     return util.makeNumber(value)
   }
 }
@@ -276,14 +237,8 @@ class OpToText extends OpConvertBase {
     super('toText', arg)
   }
 
-  /**
-   * Operate on a single row.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row's index.
-   * @return The sub-expression value as text.
-   */
-  run (row, i, numRows) {
-    let value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    let value = this.arg.run(data, i)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -310,14 +265,8 @@ class OpDatetimeBase extends ExprUnary {
     this.converter = converter
   }
 
-  /**
-   * Extract a date component.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The date component's value.
-   */
-  run (row, i, numRows) {
-    const value = this.arg.run(row, i, numRows)
+  run (data, i) {
+    const value = this.arg.run(data, i)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -421,17 +370,11 @@ class OpArithmeticBase extends ExprBinary {
     this.operator = operator
   }
 
-  /**
-   * Perform a binary arithmetic operation.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The result.
-   */
-  run (row, i, numRows) {
-    const left = this.left.run(row, i, numRows)
+  run (data, i) {
+    const left = this.left.run(data, i)
     util.checkNumber(left,
                      `Require number for ${this.species}`)
-    const right = this.right.run(row, i, numRows)
+    const right = this.right.run(data, i)
     util.checkNumber(right,
                      `Require number for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
@@ -523,15 +466,9 @@ class OpExtremumBase extends ExprBinary {
     this.operator = operator
   }
 
-  /**
-   * Select an extremum.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The result.
-   */
-  run (row, i, numRows) {
-    const left = this.left.run(row, i, numRows)
-    const right = this.right.run(row, i, numRows)
+  run (data, i) {
+    const left = this.left.run(data, i)
+    const right = this.right.run(data, i)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
       : this.operator(left, right)
@@ -577,15 +514,9 @@ class OpCompareBase extends ExprBinary {
     this.operator = operator
   }
 
-  /**
-   * Perform a binary comparison operation.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The result.
-   */
-  run (row, i, numRows) {
-    const left = this.left.run(row, i, numRows)
-    const right = this.right.run(row, i, numRows)
+  run (data, i) {
+    const left = this.left.run(data, i)
+    const right = this.right.run(data, i)
     util.checkTypeEqual(left, right,
                         `Require equal types for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
@@ -685,19 +616,12 @@ class OpAnd extends OpLogicalBase {
     super('and', left, right)
   }
 
-  /**
-   * Perform short-circuit logical 'and'.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The left value if it is not truthy, otherwise the right value. The
-   * right expression is only evaluated if necessary.
-   */
-  run (row, i, numRows) {
-    const left = this.left.run(row, i, numRows)
+  run (data, i) {
+    const left = this.left.run(data, i)
     if (!left) {
       return left
     }
-    return this.right.run(row, i, numRows)
+    return this.right.run(data, i)
   }
 }
 
@@ -709,19 +633,12 @@ class OpOr extends OpLogicalBase {
     super('or', left, right)
   }
 
-  /**
-   * Perform short-circuit logical 'or'.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The left value if it is truthy, otherwise the right value. The
-   * right expression is only evaluated if necessary.
-   */
-  run (row, i, numRows) {
-    const left = this.left.run(row, i, numRows)
+  run (data, i) {
+    const left = this.left.run(data, i)
     if (left) {
       return left
     }
-    return this.right.run(row, i, numRows)
+    return this.right.run(data, i)
   }
 }
 
@@ -741,18 +658,11 @@ class OpIfElse extends ExprTernary {
     super(FAMILY, 'ifElse', left, middle, right)
   }
 
-  /**
-   * Perform short-circuit logical 'or'.
-   * @param {object} row The row to operate on.
-   * @param {number} i The row index within the dataframe.
-   * @returns The left value if the condition is truthy, otherwise the right
-   * value. The left and right expressions are only evaluated if necessary.
-   */
-  run (row, i, numRows) {
-    const cond = this.left.run(row, i, numRows)
+  run (data, i) {
+    const cond = this.left.run(data, i)
     return (cond === util.MISSING)
       ? util.MISSING
-      : (cond ? this.middle.run(row, i, numRows) : this.right.run(row, i, numRows))
+      : (cond ? this.middle.run(data, i) : this.right.run(data, i))
   }
 }
 

--- a/libs/op.js
+++ b/libs/op.js
@@ -28,8 +28,8 @@ class OpNegate extends ExprUnary {
     super(FAMILY, 'negate', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     util.checkNumber(value,
                      `Require number for ${this.name}`)
     return (value === util.MISSING) ? util.MISSING : util.safeValue(-value)
@@ -49,8 +49,8 @@ class OpAbs extends ExprUnary {
     super(FAMILY, 'abs', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     util.checkNumber(value,
                      `Require number for ${this.name}`)
     return (value === util.MISSING) ? util.MISSING : util.safeValue(Math.abs(value))
@@ -70,8 +70,8 @@ class OpNot extends ExprUnary {
     super(FAMILY, 'not', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     return (value === util.MISSING) ? util.MISSING : !util.makeLogical(value)
   }
 }
@@ -94,8 +94,8 @@ class OpTypecheckBase extends ExprUnary {
   /**
    * Check the type of a value.
    */
-  typeCheck (data, i, typeName) {
-    const value = this.arg.run(data, i)
+  typeCheck (row, i, data, typeName) {
+    const value = this.arg.run(row, i, data)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -112,8 +112,8 @@ class OpIsLogical extends OpTypecheckBase {
     super('isLogical', arg)
   }
 
-  run (data, i) {
-    return this.typeCheck(data, i, 'boolean')
+  run (row, i, data) {
+    return this.typeCheck(row, i, data, 'boolean')
   }
 }
 
@@ -125,8 +125,8 @@ class OpIsDatetime extends OpTypecheckBase {
     super('isDatetime', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     return (value === util.MISSING) ? util.MISSING : (value instanceof Date)
   }
 }
@@ -139,8 +139,8 @@ class OpIsMissing extends OpTypecheckBase {
     super('isMissing', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     return value === util.MISSING
   }
 }
@@ -153,8 +153,8 @@ class OpIsNumber extends OpTypecheckBase {
     super('isNumber', arg)
   }
 
-  run (data, i) {
-    return this.typeCheck(data, i, 'number')
+  run (row, i, data) {
+    return this.typeCheck(row, i, data, 'number')
   }
 }
 
@@ -166,8 +166,8 @@ class OpIsText extends OpTypecheckBase {
     super('isText', arg)
   }
 
-  run (data, i) {
-    return this.typeCheck(data, i, 'string')
+  run (row, i, data) {
+    return this.typeCheck(row, i, data, 'string')
   }
 }
 
@@ -195,8 +195,8 @@ class OpToLogical extends OpConvertBase {
     super('toLogical', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     return (value === util.MISSING) ? util.MISSING : util.makeLogical(value)
   }
 }
@@ -209,8 +209,8 @@ class OpToDatetime extends OpConvertBase {
     super('toDatetime', arg)
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     return util.makeDate(value)
   }
 }
@@ -223,8 +223,8 @@ class OpToNumber extends OpConvertBase {
     super('toNumber', arg)
   }
 
-  run (data, i) {
-    let value = this.arg.run(data, i)
+  run (row, i, data) {
+    let value = this.arg.run(row, i, data)
     return util.makeNumber(value)
   }
 }
@@ -237,8 +237,8 @@ class OpToText extends OpConvertBase {
     super('toText', arg)
   }
 
-  run (data, i) {
-    let value = this.arg.run(data, i)
+  run (row, i, data) {
+    let value = this.arg.run(row, i, data)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -265,8 +265,8 @@ class OpDatetimeBase extends ExprUnary {
     this.converter = converter
   }
 
-  run (data, i) {
-    const value = this.arg.run(data, i)
+  run (row, i, data) {
+    const value = this.arg.run(row, i, data)
     if (value === util.MISSING) {
       return util.MISSING
     }
@@ -370,11 +370,11 @@ class OpArithmeticBase extends ExprBinary {
     this.operator = operator
   }
 
-  run (data, i) {
-    const left = this.left.run(data, i)
+  run (row, i, data) {
+    const left = this.left.run(row, i, data)
     util.checkNumber(left,
                      `Require number for ${this.species}`)
-    const right = this.right.run(data, i)
+    const right = this.right.run(row, i, data)
     util.checkNumber(right,
                      `Require number for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
@@ -466,9 +466,9 @@ class OpExtremumBase extends ExprBinary {
     this.operator = operator
   }
 
-  run (data, i) {
-    const left = this.left.run(data, i)
-    const right = this.right.run(data, i)
+  run (row, i, data) {
+    const left = this.left.run(row, i, data)
+    const right = this.right.run(row, i, data)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
       : this.operator(left, right)
@@ -514,9 +514,9 @@ class OpCompareBase extends ExprBinary {
     this.operator = operator
   }
 
-  run (data, i) {
-    const left = this.left.run(data, i)
-    const right = this.right.run(data, i)
+  run (row, i, data) {
+    const left = this.left.run(row, i, data)
+    const right = this.right.run(row, i, data)
     util.checkTypeEqual(left, right,
                         `Require equal types for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
@@ -616,12 +616,12 @@ class OpAnd extends OpLogicalBase {
     super('and', left, right)
   }
 
-  run (data, i) {
-    const left = this.left.run(data, i)
+  run (row, i, data) {
+    const left = this.left.run(row, i, data)
     if (!left) {
       return left
     }
-    return this.right.run(data, i)
+    return this.right.run(row, i, data)
   }
 }
 
@@ -633,12 +633,12 @@ class OpOr extends OpLogicalBase {
     super('or', left, right)
   }
 
-  run (data, i) {
-    const left = this.left.run(data, i)
+  run (row, i, data) {
+    const left = this.left.run(row, i, data)
     if (left) {
       return left
     }
-    return this.right.run(data, i)
+    return this.right.run(row, i, data)
   }
 }
 
@@ -658,11 +658,11 @@ class OpIfElse extends ExprTernary {
     super(FAMILY, 'ifElse', left, middle, right)
   }
 
-  run (data, i) {
-    const cond = this.left.run(data, i)
+  run (row, i, data) {
+    const cond = this.left.run(row, i, data)
     return (cond === util.MISSING)
       ? util.MISSING
-      : (cond ? this.middle.run(data, i) : this.right.run(data, i))
+      : (cond ? this.middle.run(row, i, data) : this.right.run(row, i, data))
   }
 }
 

--- a/libs/value.js
+++ b/libs/value.js
@@ -28,7 +28,7 @@ class ValueAbsent extends ExprBase {
     return other instanceof ValueAbsent
   }
 
-  run (data, i) {
+  run (row, i, data) {
     util.fail('Missing expression')
   }
 }
@@ -48,7 +48,7 @@ class ValueMissing extends ExprBase {
     return other instanceof ValueMissing
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return util.MISSING
   }
 }
@@ -68,7 +68,7 @@ class ValueRowNum extends ExprBase {
     return other instanceof ValueRowNum
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return i
   }
 }
@@ -89,10 +89,9 @@ class ValueColumn extends ExprValue {
     super(FAMILY, 'column', name)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     util.check((0 <= i) && (i < data.length),
                `Row index ${i} out of range`)
-    const row = data[i]
     util.check(typeof row === 'object',
                `Row must be object`)
     util.check(this.value in row,
@@ -116,7 +115,7 @@ class ValueDatetime extends ExprValue {
     super(FAMILY, 'datetime', value)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.value
   }
 }
@@ -135,7 +134,7 @@ class ValueLogical extends ExprValue {
     super(FAMILY, 'logical', value)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.value
   }
 }
@@ -154,7 +153,7 @@ class ValueNumber extends ExprValue {
     super(FAMILY, 'number', value)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.value
   }
 }
@@ -173,7 +172,7 @@ class ValueText extends ExprValue {
     super(FAMILY, 'text', value)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.value
   }
 }
@@ -193,7 +192,7 @@ class ValueExponential extends ExprValue {
     this.generator = random.exponential(this.value)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.generator()
   }
 }
@@ -229,7 +228,7 @@ class ValueNormal extends ExprBase {
       (this.stdDev === other.stdDev)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.generator()
   }
 }
@@ -267,7 +266,7 @@ class ValueUniform extends ExprBase {
       (this.high === other.high)
   }
 
-  run (data, i) {
+  run (row, i, data) {
     return this.generator()
   }
 }

--- a/libs/value.js
+++ b/libs/value.js
@@ -28,7 +28,7 @@ class ValueAbsent extends ExprBase {
     return other instanceof ValueAbsent
   }
 
-  run (row, i, numRows) {
+  run (data, i) {
     util.fail('Missing expression')
   }
 }
@@ -48,7 +48,7 @@ class ValueMissing extends ExprBase {
     return other instanceof ValueMissing
   }
 
-  run (row, i, numRows) {
+  run (data, i) {
     return util.MISSING
   }
 }
@@ -68,7 +68,7 @@ class ValueRowNum extends ExprBase {
     return other instanceof ValueRowNum
   }
 
-  run (row, i, numRows) {
+  run (data, i) {
     return i
   }
 }
@@ -89,13 +89,10 @@ class ValueColumn extends ExprValue {
     super(FAMILY, 'column', name)
   }
 
-  /**
-   * Extract the value of a column given its name.
-   * @param row The row.
-   * @param i The row number.
-   * @returns The value (of any type).
-   */
-  run (row, i, numRows) {
+  run (data, i) {
+    util.check((0 <= i) && (i < data.length),
+               `Row index ${i} out of range`)
+    const row = data[i]
     util.check(typeof row === 'object',
                `Row must be object`)
     util.check(this.value in row,
@@ -119,13 +116,7 @@ class ValueDatetime extends ExprValue {
     super(FAMILY, 'datetime', value)
   }
 
-  /**
-   * Produce the constant datetime value.
-   * @param row The row.
-   * @param i The row number.
-   * @returns The constant datetime value.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.value
   }
 }
@@ -144,13 +135,7 @@ class ValueLogical extends ExprValue {
     super(FAMILY, 'logical', value)
   }
 
-  /**
-   * Produce the constant logical value.
-   * @param row The row.
-   * @param i The row number.
-   * @returns The constant logical value.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.value
   }
 }
@@ -169,13 +154,7 @@ class ValueNumber extends ExprValue {
     super(FAMILY, 'number', value)
   }
 
-  /**
-   * Produce the constant numeric value.
-   * @param row The row.
-   * @param i The row number.
-   * @returns The constant numeric value.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.value
   }
 }
@@ -194,13 +173,7 @@ class ValueText extends ExprValue {
     super(FAMILY, 'text', value)
   }
 
-  /**
-   * Produce the constant text value.
-   * @param row The row.
-   * @param i The row number.
-   * @returns The constant text value.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.value
   }
 }
@@ -220,13 +193,7 @@ class ValueExponential extends ExprValue {
     this.generator = random.exponential(this.value)
   }
 
-  /**
-   * Produce a sample from the exponential distribution.
-   * @param row The row.
-   * @param i The row number.
-   * @returns A sample from the distribution.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.generator()
   }
 }
@@ -262,13 +229,7 @@ class ValueNormal extends ExprBase {
       (this.stdDev === other.stdDev)
   }
 
-  /**
-   * Produce a sample from the normal distribution.
-   * @param row The row.
-   * @param i The row number.
-   * @returns A sample from the distribution.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.generator()
   }
 }
@@ -306,13 +267,7 @@ class ValueUniform extends ExprBase {
       (this.high === other.high)
   }
 
-  /**
-   * Produce a sample from the uniform distribution.
-   * @param row The row.
-   * @param i The row number.
-   * @returns A sample from the distribution.
-   */
-  run (row, i, numRows) {
+  run (data, i) {
     return this.generator()
   }
 }

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -121,6 +121,9 @@ module.exports = {
     {num: -1, date: new Date(), str: "abc", bool: true},
     {num: util.MISSING, date: util.MISSING, str: util.MISSING, bool: util.MISSING}
   ],
+  SINGLE: [
+    {num: 0}
+  ],
   COLORS: require('../data/colors'),
   TABLE,
   HEAD: new MockTransform('head', (runner, df) => TABLE, [], false, false),

--- a/test/test_op.js
+++ b/test/test_op.js
@@ -23,8 +23,7 @@ describe('arithmetic operations', () => {
   it('adds', (done) => {
     const expected = [4, 3, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.add(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for add`)
     done()
@@ -33,8 +32,7 @@ describe('arithmetic operations', () => {
   it('divides', (done) => {
     const expected = [1.0, -2.5, util.MISSING, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.divide(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for divide`)
     done()
@@ -43,8 +41,7 @@ describe('arithmetic operations', () => {
   it('exponentiates', (done) => {
     const expected = [4, 0.04, 1, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.power(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for power`)
     done()
@@ -53,8 +50,7 @@ describe('arithmetic operations', () => {
   it('multiplies', (done) => {
     const expected = [4, -10, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.multiply(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for multiply`)
     done()
@@ -63,8 +59,7 @@ describe('arithmetic operations', () => {
   it('negates', (done) => {
     const expected = [-2, 2, 0, -3, util.MISSING, util.MISSING]
     const op = new Op.negate(getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for negate`)
     done()
@@ -73,8 +68,7 @@ describe('arithmetic operations', () => {
   it('absolute value', (done) => {
     const expected = [2, 2, 0, 3, util.MISSING, util.MISSING]
     const op = new Op.abs(getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for absolute value`)
     done()
@@ -83,8 +77,7 @@ describe('arithmetic operations', () => {
   it('remainders', (done) => {
     const expected = [0, 1, util.MISSING, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.remainder(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for power`)
     done()
@@ -93,8 +86,7 @@ describe('arithmetic operations', () => {
   it('subtracts', (done) => {
     const expected = [0, 7, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.subtract(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for subtract`)
     done()
@@ -105,8 +97,7 @@ describe('logical operations', () => {
   it('ands', (done) => {
     const expected = [true, false, false, false, util.MISSING, false, util.MISSING]
     const op = new Op.and(getLeft, getRight)
-    const data = fixture.BOOL
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.BOOL.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for and`)
     done()
@@ -115,8 +106,7 @@ describe('logical operations', () => {
   it('nots', (done) => {
     const expected = [false, false, true, true, util.MISSING, true, util.MISSING]
     const op = new Op.not(getLeft)
-    const data = fixture.BOOL
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.BOOL.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not`)
     done()
@@ -125,8 +115,7 @@ describe('logical operations', () => {
   it('ors', (done) => {
     const expected = [true, true, true, false, false, util.MISSING, util.MISSING]
     const op = new Op.or(getLeft, getRight)
-    const data = fixture.BOOL
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.BOOL.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for or`)
     done()
@@ -137,8 +126,7 @@ describe('extrema', () => {
   it('finds maximum numbers', (done) => {
     const expected = [2, 5, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.maximum(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for maximum numbers`)
     done()
@@ -147,8 +135,7 @@ describe('extrema', () => {
   it('finds minimum numbers', (done) => {
     const expected = [2, -2, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.minimum(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for minimum numbers`)
     done()
@@ -157,8 +144,7 @@ describe('extrema', () => {
   it('finds maximum strings', (done) => {
     const expected = ['pqr', 'def', 'def', 'abc', util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.maximum(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for maximum strings`)
     done()
@@ -167,8 +153,7 @@ describe('extrema', () => {
   it('finds minimum strings', (done) => {
     const expected = ['pqr', 'abc', 'abc', '', util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.minimum(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for minimum strings`)
     done()
@@ -179,8 +164,7 @@ describe('comparison on numbers', () => {
   it('greater numbers', (done) => {
     const expected = [false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greater(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater numbers`)
     done()
@@ -189,8 +173,7 @@ describe('comparison on numbers', () => {
   it('greater equals numbers', (done) => {
     const expected = [true, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greaterEqual(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater equal numbers`)
     done()
@@ -199,8 +182,7 @@ describe('comparison on numbers', () => {
   it('equals numbers', (done) => {
     const expected = [true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.equal(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for equal numbers`)
     done()
@@ -209,8 +191,7 @@ describe('comparison on numbers', () => {
   it('not equals numbers', (done) => {
     const expected = [false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.notEqual(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not equal numbers`)
     done()
@@ -219,8 +200,7 @@ describe('comparison on numbers', () => {
   it('less equals numbers', (done) => {
     const expected = [true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.lessEqual(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less equal numbers`)
     done()
@@ -229,8 +209,7 @@ describe('comparison on numbers', () => {
   it('less numbers', (done) => {
     const expected = [false, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.less(getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less numbers`)
     done()
@@ -241,8 +220,7 @@ describe('comparison on strings', () => {
   it('greater strings', (done) => {
     const expected = [false, false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greater(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater strings`)
     done()
@@ -251,8 +229,7 @@ describe('comparison on strings', () => {
   it('greater equals strings', (done) => {
     const expected = [true, false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greaterEqual(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater equal strings`)
     done()
@@ -261,8 +238,7 @@ describe('comparison on strings', () => {
   it('equals strings', (done) => {
     const expected = [true, false, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.equal(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for equal strings`)
     done()
@@ -271,8 +247,7 @@ describe('comparison on strings', () => {
   it('not equals strings', (done) => {
     const expected = [false, true, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.notEqual(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not equal strings`)
     done()
@@ -281,8 +256,7 @@ describe('comparison on strings', () => {
   it('less equals strings', (done) => {
     const expected = [true, true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.lessEqual(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less equal strings`)
     done()
@@ -291,8 +265,7 @@ describe('comparison on strings', () => {
   it('less strings', (done) => {
     const expected = [false, true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.less(getLeft, getRight)
-    const data = fixture.STRING
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.STRING.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less strings`)
     done()
@@ -304,7 +277,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(4000))
     const op = new Op.greater(test, getDate)
     const expected = [true, true, true]
-    const actual = threeDates.map((row, i) => op.run(threeDates, i))
+    const actual = threeDates.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for greater dates`)
     done()
@@ -314,7 +287,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.greaterEqual(test, getDate)
     const expected = [true, true, false]
-    const actual = threeDates.map((row, i) => op.run(threeDates, i))
+    const actual = threeDates.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for greater equal dates`)
     done()
@@ -324,7 +297,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.equal(test, getDate)
     const expected = [false, true, false]
-    const actual = threeDates.map((row, i) => op.run(threeDates, i))
+    const actual = threeDates.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for equal dates`)
     done()
@@ -334,7 +307,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.notEqual(test, getDate)
     const expected = [true, false, true]
-    const actual = threeDates.map((row, i) => op.run(threeDates, i))
+    const actual = threeDates.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for not equal dates`)
     done()
@@ -344,7 +317,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.lessEqual(test, getDate)
     const expected = [false, true, true]
-    const actual = threeDates.map((row, i) => op.run(threeDates, i))
+    const actual = threeDates.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for less equal dates`)
     done()
@@ -354,7 +327,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(1))
     const op = new Op.less(test, getDate)
     const expected = [false, true, true]
-    const actual = threeDates.map((row, i) => op.run(threeDates, i))
+    const actual = threeDates.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for less dates`)
     done()
@@ -365,8 +338,7 @@ describe('conditional', () => {
   it('pulls values conditionally', (done) => {
     const expected = [2, 5, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.ifElse(getRight, getLeft, getRight)
-    const data = fixture.NUMBER
-    const actual = data.map((row, i) => op.run(data, i))
+    const actual = fixture.NUMBER.map((r, i, d) => op.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for conditional`)
     done()
@@ -389,9 +361,8 @@ describe('type checks', () => {
       [new Op.isDatetime(getStr), 'datetime', 'str'],
       [new Op.isNumber(getStr), 'num', 'str']
     ]
-    const data = fixture.MIXED
     for (const [check, tested, actual] of allChecks) {
-      assert.deepEqual(data.map((row, i) => check.run(data, i)),
+      assert.deepEqual(fixture.MIXED.map((r, i, d) => check.run(r, i, d)),
                        [false, util.MISSING],
                        `Should not think ${actual} is ${tested}`)
     }
@@ -405,9 +376,8 @@ describe('type checks', () => {
       [new Op.isNumber(getNum), 'num'],
       [new Op.isText(getStr), 'text']
     ]
-    const data = fixture.MIXED
     for (const [check, name] of allChecks) {
-      assert.deepEqual(data.map((row, i) => check.run(data, i)),
+      assert.deepEqual(fixture.MIXED.map((r, i, d) => check.run(r, i, d)),
                        [true, util.MISSING],
                        `Incorrect result(s) for ${name}`)
     }
@@ -421,10 +391,9 @@ describe('type checks', () => {
       [getNum, 'num'],
       [getStr, 'text']
     ]
-    const data = fixture.MIXED
     for (const [get, name] of allChecks) {
       const check = new Op.isMissing(get)
-      assert.deepEqual(data.map((row, i) => check.run(data, i)),
+      assert.deepEqual(fixture.MIXED.map((r, i, d) => check.run(r, i, d)),
                        [false, true],
                        `Incorrect result(s) for ${name}`)
     }
@@ -459,7 +428,7 @@ describe('type conversions', () => {
     ]
     for (const [value, convert, expected] of checks) {
       const op = new convert(value)
-      const actual = op.run([{}], 0)
+      const actual = op.run(fixture.SINGLE[0], 0, fixture.SINGLE)
       assert.equal(actual, expected,
                    `Wrong result for ${value} and ${convert}: expected ${expected}, got ${actual}`)
     }
@@ -471,7 +440,7 @@ describe('type conversions', () => {
                     new Value.text('abc')]
     for (const input of checks) {
       const op = new Op.toDatetime(input)
-      assert.throws(() => op.run([{}], 0),
+      assert.throws(() => op.run(fixture.SINGLE[0], 0, fixture.SINGLE),
                     Error,
                     `Should not be able to convert "${input}"`)
     }
@@ -485,14 +454,14 @@ describe('type conversions', () => {
     ]
     for (const [expr, expected] of checks) {
       const op = new Op.toDatetime(expr)
-      const actual = op.run([{}], 0)
+      const actual = op.run(fixture.SINGLE[0], 0, fixture.SINGLE)
       assert(actual instanceof Date,
              `Wrong result type for ${expected}`)
       assert.equal(actual.getTime(), expected.getTime(),
                    `Wrong result for ${expected}`)
     }
     const op = new Op.toDatetime(new Value.number(util.MISSING))
-    const actual = op.run([{}], 0)
+    const actual = op.run(fixture.SINGLE[0], 0, fixture.SINGLE)
     assert.equal(actual, util.MISSING,
                  `Should have MISSING`)
     done()
@@ -503,19 +472,19 @@ describe('extract values from datetimes', () => {
   it('extracts components of datetimes', (done) => {
     // Zero-based month in constructor *sigh*.
     const value = new Value.datetime(new Date(1983, 11, 2, 7, 55, 19, 0))
-    assert.equal((new Op.toYear(value)).run([{}], 0), 1983,
+    assert.equal((new Op.toYear(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 1983,
                  `Wrong year`)
-    assert.equal((new Op.toMonth(value)).run([{}], 0), 12,
+    assert.equal((new Op.toMonth(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 12,
                  `Wrong month`)
-    assert.equal((new Op.toDay(value)).run([{}], 0), 2,
+    assert.equal((new Op.toDay(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 2,
                  `Wrong day`)
-    assert.equal((new Op.toWeekday(value)).run([{}], 0), 5,
+    assert.equal((new Op.toWeekday(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 5,
                  `Wrong weekday`)
-    assert.equal((new Op.toHours(value)).run([{}], 0), 7,
+    assert.equal((new Op.toHours(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 7,
                  `Wrong hours`)
-    assert.equal((new Op.toMinutes(value)).run([{}], 0), 55,
+    assert.equal((new Op.toMinutes(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 55,
                  `Wrong minutes`)
-    assert.equal((new Op.toSeconds(value)).run([{}], 0), 19,
+    assert.equal((new Op.toSeconds(value)).run(fixture.SINGLE[0], 0, fixture.SINGLE), 19,
                  `Wrong seconds`)
     done()
   })
@@ -533,7 +502,7 @@ describe('extract values from datetimes', () => {
     const value = new Value.datetime(util.MISSING)
     for (const [name, conv] of converters) {
       const op = new conv(value)
-      const result = op.run([{}], 0)
+      const result = op.run(fixture.SINGLE[0], 0, fixture.SINGLE)
       assert.equal(result, util.MISSING,
                    `Wrong result for ${name}`)
     }

--- a/test/test_op.js
+++ b/test/test_op.js
@@ -23,8 +23,8 @@ describe('arithmetic operations', () => {
   it('adds', (done) => {
     const expected = [4, 3, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.add(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for add`)
     done()
@@ -33,8 +33,8 @@ describe('arithmetic operations', () => {
   it('divides', (done) => {
     const expected = [1.0, -2.5, util.MISSING, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.divide(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for divide`)
     done()
@@ -43,8 +43,8 @@ describe('arithmetic operations', () => {
   it('exponentiates', (done) => {
     const expected = [4, 0.04, 1, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.power(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for power`)
     done()
@@ -53,8 +53,8 @@ describe('arithmetic operations', () => {
   it('multiplies', (done) => {
     const expected = [4, -10, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.multiply(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for multiply`)
     done()
@@ -63,8 +63,8 @@ describe('arithmetic operations', () => {
   it('negates', (done) => {
     const expected = [-2, 2, 0, -3, util.MISSING, util.MISSING]
     const op = new Op.negate(getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for negate`)
     done()
@@ -73,8 +73,8 @@ describe('arithmetic operations', () => {
   it('absolute value', (done) => {
     const expected = [2, 2, 0, 3, util.MISSING, util.MISSING]
     const op = new Op.abs(getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for absolute value`)
     done()
@@ -83,8 +83,8 @@ describe('arithmetic operations', () => {
   it('remainders', (done) => {
     const expected = [0, 1, util.MISSING, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.remainder(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for power`)
     done()
@@ -93,8 +93,8 @@ describe('arithmetic operations', () => {
   it('subtracts', (done) => {
     const expected = [0, 7, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.subtract(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for subtract`)
     done()
@@ -105,8 +105,8 @@ describe('logical operations', () => {
   it('ands', (done) => {
     const expected = [true, false, false, false, util.MISSING, false, util.MISSING]
     const op = new Op.and(getLeft, getRight)
-    const numRows = fixture.BOOL.length
-    const actual = fixture.BOOL.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.BOOL
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for and`)
     done()
@@ -115,8 +115,8 @@ describe('logical operations', () => {
   it('nots', (done) => {
     const expected = [false, false, true, true, util.MISSING, true, util.MISSING]
     const op = new Op.not(getLeft)
-    const numRows = fixture.BOOL.length
-    const actual = fixture.BOOL.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.BOOL
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not`)
     done()
@@ -125,8 +125,8 @@ describe('logical operations', () => {
   it('ors', (done) => {
     const expected = [true, true, true, false, false, util.MISSING, util.MISSING]
     const op = new Op.or(getLeft, getRight)
-    const numRows = fixture.BOOL.length
-    const actual = fixture.BOOL.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.BOOL
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for or`)
     done()
@@ -137,8 +137,8 @@ describe('extrema', () => {
   it('finds maximum numbers', (done) => {
     const expected = [2, 5, 2, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.maximum(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for maximum numbers`)
     done()
@@ -147,8 +147,8 @@ describe('extrema', () => {
   it('finds minimum numbers', (done) => {
     const expected = [2, -2, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.minimum(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for minimum numbers`)
     done()
@@ -157,8 +157,8 @@ describe('extrema', () => {
   it('finds maximum strings', (done) => {
     const expected = ['pqr', 'def', 'def', 'abc', util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.maximum(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for maximum strings`)
     done()
@@ -167,8 +167,8 @@ describe('extrema', () => {
   it('finds minimum strings', (done) => {
     const expected = ['pqr', 'abc', 'abc', '', util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.minimum(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for minimum strings`)
     done()
@@ -179,8 +179,8 @@ describe('comparison on numbers', () => {
   it('greater numbers', (done) => {
     const expected = [false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greater(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater numbers`)
     done()
@@ -189,8 +189,8 @@ describe('comparison on numbers', () => {
   it('greater equals numbers', (done) => {
     const expected = [true, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greaterEqual(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater equal numbers`)
     done()
@@ -199,8 +199,8 @@ describe('comparison on numbers', () => {
   it('equals numbers', (done) => {
     const expected = [true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.equal(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for equal numbers`)
     done()
@@ -209,8 +209,8 @@ describe('comparison on numbers', () => {
   it('not equals numbers', (done) => {
     const expected = [false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.notEqual(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not equal numbers`)
     done()
@@ -219,8 +219,8 @@ describe('comparison on numbers', () => {
   it('less equals numbers', (done) => {
     const expected = [true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.lessEqual(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less equal numbers`)
     done()
@@ -229,8 +229,8 @@ describe('comparison on numbers', () => {
   it('less numbers', (done) => {
     const expected = [false, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.less(getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less numbers`)
     done()
@@ -241,8 +241,8 @@ describe('comparison on strings', () => {
   it('greater strings', (done) => {
     const expected = [false, false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greater(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater strings`)
     done()
@@ -251,8 +251,8 @@ describe('comparison on strings', () => {
   it('greater equals strings', (done) => {
     const expected = [true, false, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.greaterEqual(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for greater equal strings`)
     done()
@@ -261,8 +261,8 @@ describe('comparison on strings', () => {
   it('equals strings', (done) => {
     const expected = [true, false, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.equal(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for equal strings`)
     done()
@@ -271,8 +271,8 @@ describe('comparison on strings', () => {
   it('not equals strings', (done) => {
     const expected = [false, true, true, true, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.notEqual(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for not equal strings`)
     done()
@@ -281,8 +281,8 @@ describe('comparison on strings', () => {
   it('less equals strings', (done) => {
     const expected = [true, true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.lessEqual(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less equal strings`)
     done()
@@ -291,8 +291,8 @@ describe('comparison on strings', () => {
   it('less strings', (done) => {
     const expected = [false, true, false, false, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.less(getLeft, getRight)
-    const numRows = fixture.STRING.length
-    const actual = fixture.STRING.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.STRING
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for less strings`)
     done()
@@ -304,8 +304,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(4000))
     const op = new Op.greater(test, getDate)
     const expected = [true, true, true]
-    const numRows = threeDates.length
-    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
+    const actual = threeDates.map((row, i) => op.run(threeDates, i))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for greater dates`)
     done()
@@ -315,8 +314,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.greaterEqual(test, getDate)
     const expected = [true, true, false]
-    const numRows = threeDates.length
-    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
+    const actual = threeDates.map((row, i) => op.run(threeDates, i))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for greater equal dates`)
     done()
@@ -326,8 +324,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.equal(test, getDate)
     const expected = [false, true, false]
-    const numRows = threeDates.length
-    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
+    const actual = threeDates.map((row, i) => op.run(threeDates, i))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for equal dates`)
     done()
@@ -337,8 +334,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.notEqual(test, getDate)
     const expected = [true, false, true]
-    const numRows = threeDates.length
-    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
+    const actual = threeDates.map((row, i) => op.run(threeDates, i))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for not equal dates`)
     done()
@@ -348,8 +344,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(20))
     const op = new Op.lessEqual(test, getDate)
     const expected = [false, true, true]
-    const numRows = threeDates.length
-    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
+    const actual = threeDates.map((row, i) => op.run(threeDates, i))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for less equal dates`)
     done()
@@ -359,8 +354,7 @@ describe('comparison on dates', () => {
     const test = new Value.datetime(new Date(1))
     const op = new Op.less(test, getDate)
     const expected = [false, true, true]
-    const numRows = threeDates.length
-    const actual = threeDates.map((row, i) => op.run(row, i, numRows))
+    const actual = threeDates.map((row, i) => op.run(threeDates, i))
     assert.deepEqual(expected, actual,
                      `Wrong result(s) for less dates`)
     done()
@@ -371,8 +365,8 @@ describe('conditional', () => {
   it('pulls values conditionally', (done) => {
     const expected = [2, 5, 0, util.MISSING, util.MISSING, util.MISSING]
     const op = new Op.ifElse(getRight, getLeft, getRight)
-    const numRows = fixture.NUMBER.length
-    const actual = fixture.NUMBER.map((row, i) => op.run(row, i, numRows))
+    const data = fixture.NUMBER
+    const actual = data.map((row, i) => op.run(data, i))
     assert.deepEqual(expected, actual,
                      `Wrong value(s) for conditional`)
     done()
@@ -395,9 +389,9 @@ describe('type checks', () => {
       [new Op.isDatetime(getStr), 'datetime', 'str'],
       [new Op.isNumber(getStr), 'num', 'str']
     ]
-    const numRows = fixture.MIXED.length
+    const data = fixture.MIXED
     for (const [check, tested, actual] of allChecks) {
-      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i, numRows)),
+      assert.deepEqual(data.map((row, i) => check.run(data, i)),
                        [false, util.MISSING],
                        `Should not think ${actual} is ${tested}`)
     }
@@ -411,9 +405,9 @@ describe('type checks', () => {
       [new Op.isNumber(getNum), 'num'],
       [new Op.isText(getStr), 'text']
     ]
-    const numRows = fixture.MIXED.length
+    const data = fixture.MIXED
     for (const [check, name] of allChecks) {
-      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i, numRows)),
+      assert.deepEqual(data.map((row, i) => check.run(data, i)),
                        [true, util.MISSING],
                        `Incorrect result(s) for ${name}`)
     }
@@ -427,10 +421,10 @@ describe('type checks', () => {
       [getNum, 'num'],
       [getStr, 'text']
     ]
-    const numRows = fixture.MIXED.length
+    const data = fixture.MIXED
     for (const [get, name] of allChecks) {
       const check = new Op.isMissing(get)
-      assert.deepEqual(fixture.MIXED.map((row, i) => check.run(row, i, numRows)),
+      assert.deepEqual(data.map((row, i) => check.run(data, i)),
                        [false, true],
                        `Incorrect result(s) for ${name}`)
     }
@@ -465,7 +459,7 @@ describe('type conversions', () => {
     ]
     for (const [value, convert, expected] of checks) {
       const op = new convert(value)
-      const actual = op.run({}, 0, 1)
+      const actual = op.run([{}], 0)
       assert.equal(actual, expected,
                    `Wrong result for ${value} and ${convert}: expected ${expected}, got ${actual}`)
     }
@@ -477,7 +471,7 @@ describe('type conversions', () => {
                     new Value.text('abc')]
     for (const input of checks) {
       const op = new Op.toDatetime(input)
-      assert.throws(() => op.run({}, 0, 1),
+      assert.throws(() => op.run([{}], 0),
                     Error,
                     `Should not be able to convert "${input}"`)
     }
@@ -491,14 +485,14 @@ describe('type conversions', () => {
     ]
     for (const [expr, expected] of checks) {
       const op = new Op.toDatetime(expr)
-      const actual = op.run({}, 0, 1)
+      const actual = op.run([{}], 0)
       assert(actual instanceof Date,
              `Wrong result type for ${expected}`)
       assert.equal(actual.getTime(), expected.getTime(),
                    `Wrong result for ${expected}`)
     }
     const op = new Op.toDatetime(new Value.number(util.MISSING))
-    const actual = op.run({}, 0, 1)
+    const actual = op.run([{}], 0)
     assert.equal(actual, util.MISSING,
                  `Should have MISSING`)
     done()
@@ -509,19 +503,19 @@ describe('extract values from datetimes', () => {
   it('extracts components of datetimes', (done) => {
     // Zero-based month in constructor *sigh*.
     const value = new Value.datetime(new Date(1983, 11, 2, 7, 55, 19, 0))
-    assert.equal((new Op.toYear(value)).run({}, 0, 1), 1983,
+    assert.equal((new Op.toYear(value)).run([{}], 0), 1983,
                  `Wrong year`)
-    assert.equal((new Op.toMonth(value)).run({}, 0, 1), 12,
+    assert.equal((new Op.toMonth(value)).run([{}], 0), 12,
                  `Wrong month`)
-    assert.equal((new Op.toDay(value)).run({}, 0, 1), 2,
+    assert.equal((new Op.toDay(value)).run([{}], 0), 2,
                  `Wrong day`)
-    assert.equal((new Op.toWeekday(value)).run({}, 0, 1), 5,
+    assert.equal((new Op.toWeekday(value)).run([{}], 0), 5,
                  `Wrong weekday`)
-    assert.equal((new Op.toHours(value)).run({}, 0, 1), 7,
+    assert.equal((new Op.toHours(value)).run([{}], 0), 7,
                  `Wrong hours`)
-    assert.equal((new Op.toMinutes(value)).run({}, 0, 1), 55,
+    assert.equal((new Op.toMinutes(value)).run([{}], 0), 55,
                  `Wrong minutes`)
-    assert.equal((new Op.toSeconds(value)).run({}, 0, 1), 19,
+    assert.equal((new Op.toSeconds(value)).run([{}], 0), 19,
                  `Wrong seconds`)
     done()
   })
@@ -539,7 +533,7 @@ describe('extract values from datetimes', () => {
     const value = new Value.datetime(util.MISSING)
     for (const [name, conv] of converters) {
       const op = new conv(value)
-      const result = op.run({}, 0, 1)
+      const result = op.run([{}], 0)
       assert.equal(result, util.MISSING,
                    `Wrong result for ${name}`)
     }

--- a/test/test_value.js
+++ b/test/test_value.js
@@ -22,8 +22,9 @@ describe('get values', () => {
   })
 
   it('gets values from rows', (done) => {
+    const data = fixture.NUMBER
     const expected = [2, 5, 2, util.MISSING, 4, util.MISSING]
-    const actual = fixture.NUMBER.map((row, i) => getLeft.run(row, i))
+    const actual = data.map((row, i) => getLeft.run(data, i))
     assert.deepEqual(expected, actual,
                      `Got wrong value(s)`)
     done()
@@ -31,7 +32,7 @@ describe('get values', () => {
 
   it('does not get values from nonexistent columns', (done) => {
     const getNope = new Value.column('nope')
-    assert.throws(() => getNope({left: 1}, 0),
+    assert.throws(() => getNope([{left: 1}], 0),
                   Error,
                   `Should not be able to get value for missing column`)
     done()
@@ -46,8 +47,9 @@ describe('get values', () => {
 
   it('injects missing values', (done) => {
     const missing = new Value.missing()
+    const data = fixture.NAMES
     const expected = [util.MISSING, util.MISSING, util.MISSING]
-    const actual = fixture.NAMES.map((row, i) => missing.run(row, i))
+    const actual = data.map((row, i) => missing.run(data, i))
     assert.deepEqual(expected, actual,
                      `Got wrong value(s)`)
     assert(missing.equal(new Value.missing()),
@@ -59,8 +61,9 @@ describe('get values', () => {
 
   it('extracts row numbers', (done) => {
     const rownum = new Value.rownum()
+    const data = fixture.NUMBER
     const expected = [0, 1, 2, 3, 4, 5]
-    const actual = fixture.NUMBER.map((row, i) => rownum.run(row, i))
+    const actual = data.map((row, i) => rownum.run(data, i))
     assert.deepEqual(expected, actual,
                      `Got wrong value(s)`)
     assert(rownum.equal(new Value.rownum()),
@@ -71,9 +74,10 @@ describe('get values', () => {
   })
 
   it('generates exponential values', (done) => {
+    const data = fixture.NUMBER
     const exponential = new Value.exponential(1.0)
-    const actual = fixture.NUMBER.map((row, i) => exponential.run(row, i))
-    assert.equal(fixture.NUMBER.length, actual.length,
+    const actual = data.map((row, i) => exponential.run(data, i))
+    assert.equal(data.length, actual.length,
                  `Wrong number of values`)
     assert(actual.every(x => (0 <= x)),
            `Expected non-negative values`)
@@ -81,9 +85,10 @@ describe('get values', () => {
   })
 
   it('generates normal values', (done) => {
+    const data = fixture.NUMBER
     const normal = new Value.normal(5.0, 0.1)
-    const actual = fixture.NUMBER.map((row, i) => normal.run(row, i))
-    assert.equal(fixture.NUMBER.length, actual.length,
+    const actual = data.map((row, i) => normal.run(data, i))
+    assert.equal(data.length, actual.length,
                  `Wrong number of values`)
     assert(actual.every(x => (0 <= x)),
            `Expected non-negative values`)
@@ -95,9 +100,10 @@ describe('get values', () => {
   })
 
   it('generates uniform values', (done) => {
+    const data = fixture.NUMBER
     const uniform = new Value.uniform(1.0, 2.0)
-    const actual = fixture.NUMBER.map((row, i) => uniform.run(row, i))
-    assert.equal(fixture.NUMBER.length, actual.length,
+    const actual = data.map((row, i) => uniform.run(data, i))
+    assert.equal(data.length, actual.length,
                  `Wrong number of values`)
     assert(actual.every(x => ((1.0 <= x) && (x <= 2.0))),
            `Expected values in range`)

--- a/test/test_value.js
+++ b/test/test_value.js
@@ -15,7 +15,7 @@ describe('get values', () => {
            `Absent values should be equal`)
     assert(!value.equal(null),
            `Absent value should not equal null`)
-    assert.throws(() => value.run([], 0),
+    assert.throws(() => value.run(fixture.SINGLE[0], 0, fixture.SINGLE),
                   Error,
                   `Running absent value should produce error`)
     done()
@@ -24,7 +24,7 @@ describe('get values', () => {
   it('gets values from rows', (done) => {
     const data = fixture.NUMBER
     const expected = [2, 5, 2, util.MISSING, 4, util.MISSING]
-    const actual = data.map((row, i) => getLeft.run(data, i))
+    const actual = data.map((r, i, d) => getLeft.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Got wrong value(s)`)
     done()
@@ -49,7 +49,7 @@ describe('get values', () => {
     const missing = new Value.missing()
     const data = fixture.NAMES
     const expected = [util.MISSING, util.MISSING, util.MISSING]
-    const actual = data.map((row, i) => missing.run(data, i))
+    const actual = data.map((r, i, d) => missing.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Got wrong value(s)`)
     assert(missing.equal(new Value.missing()),
@@ -63,7 +63,7 @@ describe('get values', () => {
     const rownum = new Value.rownum()
     const data = fixture.NUMBER
     const expected = [0, 1, 2, 3, 4, 5]
-    const actual = data.map((row, i) => rownum.run(data, i))
+    const actual = data.map((r, i, d) => rownum.run(r, i, d))
     assert.deepEqual(expected, actual,
                      `Got wrong value(s)`)
     assert(rownum.equal(new Value.rownum()),
@@ -76,7 +76,7 @@ describe('get values', () => {
   it('generates exponential values', (done) => {
     const data = fixture.NUMBER
     const exponential = new Value.exponential(1.0)
-    const actual = data.map((row, i) => exponential.run(data, i))
+    const actual = data.map((r, i, d) => exponential.run(r, i, d))
     assert.equal(data.length, actual.length,
                  `Wrong number of values`)
     assert(actual.every(x => (0 <= x)),
@@ -87,7 +87,7 @@ describe('get values', () => {
   it('generates normal values', (done) => {
     const data = fixture.NUMBER
     const normal = new Value.normal(5.0, 0.1)
-    const actual = data.map((row, i) => normal.run(data, i))
+    const actual = data.map((r, i, d) => normal.run(r, i, d))
     assert.equal(data.length, actual.length,
                  `Wrong number of values`)
     assert(actual.every(x => (0 <= x)),
@@ -102,7 +102,7 @@ describe('get values', () => {
   it('generates uniform values', (done) => {
     const data = fixture.NUMBER
     const uniform = new Value.uniform(1.0, 2.0)
-    const actual = data.map((row, i) => uniform.run(data, i))
+    const actual = data.map((r, i, d) => uniform.run(r, i, d))
     assert.equal(data.length, actual.length,
                  `Wrong number of values`)
     assert(actual.every(x => ((1.0 <= x) && (x <= 2.0))),


### PR DESCRIPTION
Some blocks will require the whole data array in order to do their job (e.g., shift) - they can't be done row-wise.