### PR TITLE
Removing redundant 'TidyBlocks' from blog title

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,5 +1,5 @@
 ---
-title: "TidyBlocks Blog"
+title: "Blog"
 permalink: /blog/
 layout: page.liquid
 ---

--- a/blog.html
+++ b/blog.html
@@ -5,7 +5,8 @@ layout: page.liquid
 ---
 <div class="posts">
   <ul>
-  {% for post in collections.post %}
+  {% assign reversed = collections.post | reverse %}
+  {% for post in reversed %}
   <li>
     {{ post.data.date | date: "%Y-%m-%d" }}:
     <a href="{{ post.url }}">{{ post.data.title }}</a>


### PR DESCRIPTION
1. Remove redundant `TidyBlocks` from title.
2. Display posts most-recent-first.