### PR TITLE
combine_join block

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -209,8 +209,7 @@ const THEME = Blockly.Theme.defineTheme('tidyblocks', {
     data_block: {
       colourPrimary: DATA_COLOR,
       colourSecondary: '#64C7FF',
-      colourTertiary: '#9B732F',
-      hat: 'cap'
+      colourTertiary: '#9B732F'
     },
     op_block: {
       colourPrimary: OP_COLOR,

--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -190,15 +190,10 @@ const setup = (language) => {
         {
           type: 'input_statement',
           name: 'RIGHT_TABLE',
-          // do we want to check that it's a block of type data here?
-          check: '',
         },
         {
           type: 'input_statement',
           name: 'LEFT_TABLE',
-          // do we want to check that it's a block of type data here?
-          check: ''
-
         }
       ],
       inputsInline: true,

--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -185,7 +185,7 @@ const setup = (language) => {
     */
     {
       type: 'combine_join',
-      message0: 'DATA 1 %1 DATA 2%2',
+      message0: 'Right Table 1 %1 Left Table 1 2%2 Join Using: %3 %4',
       args0: [
         {
           type: 'input_statement',
@@ -194,13 +194,24 @@ const setup = (language) => {
         {
           type: 'input_statement',
           name: 'LEFT_TABLE',
-        }
+        },
+        {
+          type: 'field_input',
+          name: 'RIGHT_COLUMN',
+          text: 'right_column'
+        },
+        {
+          type: 'field_input',
+          name: 'LEFT_COLUMN',
+          text: 'left_column'
+        },
       ],
       inputsInline: true,
       nextStatement: null,
       style: 'combine_block',
       tooltip: msg.get('join.tooltip'),
-      helpUrl: './guide/#join'
+      helpUrl: './guide/#join',
+      //extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
     }
   ])
 

--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -143,6 +143,7 @@ const setup = (language) => {
       extensions: ['validate_LEFT_TABLE', 'validate_RIGHT_TABLE', 'validate_COLUMN']
     },
     // Join
+    /*
     {
       type: 'combine_join',
       message0: msg.get('join.message0'),
@@ -180,6 +181,31 @@ const setup = (language) => {
       tooltip: msg.get('join.tooltip'),
       helpUrl: './guide/#join',
       extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
+    },
+    */
+    {
+      type: 'combine_join',
+      message0: 'DATA 1 %1 DATA 2%2',
+      args0: [
+        {
+          type: 'input_statement',
+          name: 'RIGHT_TABLE',
+          // do we want to check that it's a block of type data here?
+          check: '',
+        },
+        {
+          type: 'input_statement',
+          name: 'LEFT_TABLE',
+          // do we want to check that it's a block of type data here?
+          check: ''
+
+        }
+      ],
+      inputsInline: true,
+      nextStatement: null,
+      style: 'combine_block',
+      tooltip: msg.get('join.tooltip'),
+      helpUrl: './guide/#join'
     }
   ])
 

--- a/blocks/data.js
+++ b/blocks/data.js
@@ -161,19 +161,19 @@ const setup = (language) => {
     {
       type: 'data_colors',
       message0: msg.get('colors.message0'),
+      previousStatement: null,
       nextStatement: null,
       style: 'data_block',
-      hat: 'cap',
       tooltip: msg.get('colors.tooltip'),
-      helpUrl: './guide/#colors'
+      helpUrl: './guide/#colors',
     },
     // Earthquakes
     {
       type: 'data_earthquakes',
       message0: msg.get('earthquakes.message0'),
+      previousStatement: null,
       nextStatement: null,
       style: 'data_block',
-      hat: 'cap',
       tooltip: msg.get('earthquakes.tooltip'),
       helpUrl: './guide/#earthquakes'
     },
@@ -181,9 +181,9 @@ const setup = (language) => {
     {
       type: 'data_penguins',
       message0: msg.get('penguins.message0'),
+      previousStatement: null,
       nextStatement: null,
       style: 'data_block',
-      hat: 'cap',
       tooltip: msg.get('penguins.tooltip'),
       helpUrl: './guide/#penguins'
     },
@@ -191,9 +191,9 @@ const setup = (language) => {
     {
       type: 'data_phish',
       message0: msg.get('phish.message0'),
+      previousStatement: null,
       nextStatement: null,
       style: 'data_block',
-      hat: 'cap',
       tooltip: msg.get('phish.tooltip'),
       helpUrl: './guide/#phish'
     },
@@ -214,8 +214,8 @@ const setup = (language) => {
         }
       ],
       nextStatement: null,
+      previousStatement: null,
       style: 'data_block',
-      hat: 'cap',
       tooltip: msg.get('sequence.tooltip'),
       helpUrl: './guide/#sequence'
     },
@@ -231,8 +231,8 @@ const setup = (language) => {
         }
       ],
       nextStatement: null,
+      previousStatement: null,
       style: 'data_block',
-      hat: 'cap',
       tooltip: msg.get('data_user.tooltip'),
       helpUrl: './guide/#user'
     }


### PR DESCRIPTION
# Changelog 

1. UI of join block is now an E that accepts two data frames or their output: 
2. UI of data blocks now have connection to be included within a join block:

<img width="342" alt="Screen Shot 2020-11-15 at 8 03 06 AM" src="https://user-images.githubusercontent.com/6053906/99190003-0535a700-2719-11eb-84e5-5f76db23009a.png">


Does this look like what you were envisioning, @gvwilson ? I wonder if there's a way to validate that the first connection [here: colors] is of type data (or maybe that'd be too restricting?)