### PR TITLE
Fixes parsing of links at the start of guide template.

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,0 +1,3 @@
+{
+  "repo": "https://github.com/tidyblocks/tidyblocks"
+}

--- a/en/guide.md
+++ b/en/guide.md
@@ -19,9 +19,10 @@ language: en
 </div>
 
 <div class="guide_rhs">
+
 A blocks-based tool for tidy data manipulation and analysis.
 Please see <https://tidyblocks.tech> for a free online version
-or visit [our GitHub repository]({{site.repo}}).
+or visit [our GitHub repository]({{ site.repo | absolute_url }}).
 
 This work is made freely available under the [Hippocratic License]({{ '/license/' | relative_url }}).
 Contributions of all kinds are welcome:

--- a/es/guide.md
+++ b/es/guide.md
@@ -18,6 +18,7 @@ language: es
 </div>
 
 <div class="guide_rhs">
+
 Una herramienta basada en bloques para la manipulación y el análisis de datos ordenados.
 Por favor ve a <https://tidyblocks.tech> o para una versión gratuita en línea
 visita [nuestro reprositoria de GitHub]({{site.repo}}).


### PR DESCRIPTION
The extra space seems to matter here, looks like it breaks the html parsing, and uses the liquid template stuff. We also didn't have the variable for the repo.