### PR TITLE
override letter-spacing styling for arabic nav button

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
         <li>
           <a href="#">TidyBlocks</a>
           <ul class="hidden-ul">
-            <li class="hidden-li"><a target="_blank" class="hidden-a" href="{{ '/ar/' | relative_url}}">اَلْعَرَبِيَّةُ</a></li>
+            <li class="hidden-li"><a style="letter-spacing: 0;" target="_blank" class="hidden-a" href="{{ '/ar/' | relative_url}}">اَلْعَرَبِيَّةُ</a></li>
             <br/>
             <li class="hidden-li"><a target="_blank" class="hidden-a" href="{{ '/el/' | relative_url}}">Ελληνικα</a></li>
             <br/>


### PR DESCRIPTION
Adding the styles inline feels a little messy to me; I'm open to alternative approaches. 

Another option is to remove line 34 in `static/jekyll-site.sass`

```
  .navRight a {
    color:grey;
    text-transform: uppercase;
    text-decoration: none;
    letter-spacing: 0.15em; // <-- delete this line
    padding: 15px 20px;
    position: relative;
  }
```

but that changes the styling for the entire site. 

Closes #434